### PR TITLE
APIHOST env var controls api to use

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -1,3 +1,2 @@
-/api/*  https://www.targetvalidation.org/api/:splat  200!
 /proxy/* https://proxy.targetvalidation.org/:splat 200!
 /* /index.html 200

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -1,4 +1,5 @@
 {
+    "api": "https://www.targetvalidation.org/api",
     "mastheadNavigationMenu" : [
         {
             "label" : "About",

--- a/app/js/api-service.js
+++ b/app/js/api-service.js
@@ -11,7 +11,7 @@ angular.module('cttvServices')
 /**
 * The API services, with methods to call the ElasticSearch API
 */
-    .factory('cttvAPIservice', ['$http', '$log', '$location', '$rootScope', '$q', '$timeout', 'liveConfig', function($http, $log, $location, $rootScope, $q, $timeout, liveConfig) {
+    .factory('cttvAPIservice', ['$http', '$log', '$location', '$rootScope', '$q', '$timeout', 'liveConfig', 'cttvConfig', function($http, $log, $location, $rootScope, $q, $timeout, liveConfig, cttvConfig) {
         'use strict';
 
 
@@ -55,7 +55,8 @@ angular.module('cttvServices')
         };
 
         var api = cttvApi()
-            .prefix("/api/")
+            // .prefix("/api/")
+            .prefix(cttvConfig.api)
             // .prefix('http://127.0.0.1:8123/api/')
             .version("latest")
             // .prefix("https://www.targetvalidation.org/api/")

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.
 [context.set-api.environment]
-  APIHOST = "https://beta.opentargets.io/api/"
+  APIHOST = "https://104.199.16.253/api/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Global settings applied to the whole site.
+[build]
+  base    = "/"
+  publish = "app/"
+  command = "npm install && npm run setup"
+
+# Deploy Preview context: All Deploy Previews
+# will inherit these settings.
+[context.set-api.environment]
+  APIHOST = "https://beta.opentargets.io/api/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.
 [context.set-api.environment]
-  APIHOST = "https://104.199.16.253/api/"
+  APIHOST = "https://open-targets-eu-dev.appspot.com/api/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,19 @@
   publish = "app/"
   command = "npm install && npm run setup"
 
-# Deploy Preview context: All Deploy Previews
+# Read https://www.netlify.com/docs/continuous-deployment/#deploy-contexts
+# to understand how context below works.
+
+# Master branch
+[context.production.environment]
+  APIHOST = "https://open-targets-eu-dev.appspot.com/api/"
+
+# Deploy Preview context: All Deploy Previews (ie.PRs)
 # will inherit these settings.
+[context.deploy-preview.environment]
+  APIHOST = "https://open-targets-eu-dev.appspot.com/api/"
+
+# CAREFUL!!! When you point a particular branch to a specific API below,
+# the change will not continue working once the branch is merged into master.
 [context.set-api.environment]
   APIHOST = "https://open-targets-eu-dev.appspot.com/api/"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-watch": "3.0.0",
     "jspm": "^0.16.34",
     "mkdirp": "0.5.1",
+    "through2": "^2.0.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },


### PR DESCRIPTION
Propose for handle which rest api to use in the webapp.
Setting up the env var `APIHOST` (for example `export APIHOST=https://beta.opentargets.io/api/`) modifies the `api` entry in all the configuration files (default.json and custom.json) where there is property is set. Defaults to the production API in case `APIHOST` is not set.

We can use [Netlify's env vars](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables) to control this per-branch
@LucaFumis @elipapa @apierleoni @peatroot comments / suggestions welcome