### PR TITLE
Add eslint support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+    "env": {
+        "browser": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     "rules": {
         "indent": [
             "error",
-            2
+            4
         ],
         "linebreak-style": [
             "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,8 @@ module.exports = {
         "plugin:angular/johnpapa"
     ],
     "plugins": [
-        "compat"
+        "compat",
+        "jsdoc"
     ],
     "rules": {
         "indent": [
@@ -29,15 +30,47 @@ module.exports = {
         ],
         /**
          * Angular rules
+         * By default, this uses 
          * Individual rules can be disabled, which we may wish to
          * enable at some point. For example, controllers named
          * eg. *Ctrl.js will throw an error, so the following rule
          * could be switched off (0).
          */
         // "angular/controller-name": 0
+        "angular/no-inline-template": [2, {
+            "allowSimple": true
+        }],
+        "angular/di": 2,
+        "angular/di-order": 2,
+        "angular/interval-service": 2,
+        "angular/timeout-service": 2,
+        "angular/document-service": 2,
+        "angular/no-service-method": 2,
+        "angular/log": 2,
+        "angular/directive-restrict": [2, {
+            "explicit": "always",
+            // "restrict": "E"
+        }],
         /**
          * Compatibility rules
          */
-        "compat/compat": 2
+        "compat/compat": 2,
+        /**
+         * Documentation rules
+         * For further info, see https://github.com/gajus/eslint-plugin-jsdoc
+         * (currently set as warnings only)
+         */
+        "jsdoc/check-param-names": 1,
+        "jsdoc/check-tag-names": 1,
+        "jsdoc/check-types": 1,
+        "jsdoc/newline-after-description": 1,
+        "jsdoc/require-description-complete-sentence": 1,
+        "jsdoc/require-example": 1,
+        "jsdoc/require-hyphen-before-param-description": 1,
+        "jsdoc/require-param": 1,
+        "jsdoc/require-param-description": 1,
+        "jsdoc/require-param-type": 1,
+        "jsdoc/require-returns-description": 1,
+        "jsdoc/require-returns-type": 1
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,14 @@
 module.exports = {
+    "parser": "babel-eslint",
     "env": {
         "browser": true
     },
     "extends": [
         "eslint:recommended",
         "plugin:angular/johnpapa"
+    ],
+    "plugins": [
+        "compat"
     ],
     "rules": {
         "indent": [
@@ -24,12 +28,16 @@ module.exports = {
             "always"
         ],
         /**
-         * Angular Rules
+         * Angular rules
          * Individual rules can be disabled, which we may wish to
          * enable at some point. For example, controllers named
          * eg. *Ctrl.js will throw an error, so the following rule
          * could be switched off (0).
-         */ 
+         */
         // "angular/controller-name": 0
+        /**
+         * Compatibility rules
+         */
+        "compat/compat": 2
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,10 @@ module.exports = {
     "env": {
         "browser": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "eslint:recommended",
+        "plugin:angular/johnpapa"
+    ],
     "rules": {
         "indent": [
             "error",
@@ -19,6 +22,14 @@ module.exports = {
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        /**
+         * Angular Rules
+         * Individual rules can be disabled, which we may wish to
+         * enable at some point. For example, controllers named
+         * eg. *Ctrl.js will throw an error, so the following rule
+         * could be switched off (0).
+         */ 
+        // "angular/controller-name": 0
     }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - "7"
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+cache:
+  directories:
+    - "node_modules"
+script:
+  - "npm run eslint"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "",
   "devDependencies": {
     "angular-mocks": "1.3.9",
+    "babel-eslint": "^7.2.3",
     "babel-preset-es2015": "^6.18.0",
     "babelify": "^7.3.0",
     "bower": "1.8.0",
@@ -13,6 +14,7 @@
     "del": "1.2.0",
     "eslint": "^4.3.0",
     "eslint-plugin-angular": "^3.0.0",
+    "eslint-plugin-compat": "^1.0.4",
     "gulp": "3.8.10",
     "gulp-concat": "2.6.0",
     "gulp-css-purge": "1.0.27",
@@ -75,5 +77,9 @@
     "devDependencies": {
       "babel": "npm:babel-core@^5.8.24"
     }
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not ie < 11"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "browserify": "^13.1.1",
     "del": "1.2.0",
     "eslint": "^4.3.0",
+    "eslint-plugin-angular": "^3.0.0",
     "gulp": "3.8.10",
     "gulp-concat": "2.6.0",
     "gulp-css-purge": "1.0.27",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bower": "1.8.0",
     "browserify": "^13.1.1",
     "del": "1.2.0",
+    "eslint": "^4.3.0",
     "gulp": "3.8.10",
     "gulp-concat": "2.6.0",
     "gulp-css-purge": "1.0.27",
@@ -38,7 +39,8 @@
     "full-install": "npm install && npm run setup",
     "start": "cd server && node server.js",
     "test": "./node_modules/.bin/gulp test",
-    "test-single-run": "karma start tests/unit/karma.conf.js  --single-run"
+    "test-single-run": "karma start tests/unit/karma.conf.js  --single-run",
+    "eslint": "./node_modules/.bin/eslint 'app/js/**.js'"
   },
   "dependencies": {
     "babel-polyfill": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint": "^4.3.0",
     "eslint-plugin-angular": "^3.0.0",
     "eslint-plugin-compat": "^1.0.4",
+    "eslint-plugin-jsdoc": "^3.1.2",
     "gulp": "3.8.10",
     "gulp-concat": "2.6.0",
     "gulp-css-purge": "1.0.27",


### PR DESCRIPTION
This PR adds eslint support to the webapp project.

## Customisation
The `.eslintrc.js` config file specifies which plugins and rules eslint should use. Currently, the angular, jsdoc and compat plugins are installed, with a selection of rules from each (1 means warning, 2 means error). The `eslint-plugin-compat` plugin uses the caniuse database and a supported browser list (in `package.json`) to check for browser compatibility problems.

## Running locally
Use `npm run eslint`, which runs eslint over javascript files in the `app/js` directory (we may want to revise this later).

To use eslint on other directories, use eg. `./node_modules/.bin/eslint "app/facets/**/*.js"`.

To automatically fix issues, where possible, pass the `--fix` option. We might do this against the whole code base at some suitable time (the `app/js` directory gave approximately 6000 issues of which only about 900 are *not* automatically fixable).

## Travis CI
A Travis CI job will run the linter whenever you push to github. You can see the output [here](https://travis-ci.org/opentargets/webapp).