### PR TITLE
Bibliography chips

### DIFF
--- a/app/css/_colors.scss
+++ b/app/css/_colors.scss
@@ -94,16 +94,21 @@ $clr-black-a80: rgba(0,0,0, .8);
 
 $clr-error: #b94a48;
 $clr-error-hover: #953b39;
+$clr-error-bg: lighten( $clr-error, 37% );
 
 $clr-warning: #f89406;
 $clr-warning-hover: #c67605;
 $clr-warning-highlight: #f6d7b3;    /* 25% of standard full color */
+$clr-warning-bg: lighten( $clr-warning, 37% );
 
 $clr-success: #5cb85c;
 $clr-success-hover: #449d44;
+$clr-success-bg: lighten( $clr-success, 37%);
 
 $clr-info: #3a87ad;
 $clr-info-hover: #2d6987;
+$clr-info-highlight: #f5f6ce;    /* 25% of standard full color */
+$clr-info-bg: lighten($clr-info, 37%);
 
 $clr-inverse: #333333;
 $clr-inverse-hover: #1a1a1a;
@@ -111,6 +116,4 @@ $clr-inverse-hover: #1a1a1a;
 $clr-primary: $secondary-color; //ok, this is confusing //#337ab7;
 $clr-primary-hover: adjust-color( $clr-primary, $lightness: -5% );
 $clr-primary-highlight: #b7d3e7;    /* 25% of standard full color */
-
-$clr-info-highlight: #f5f6ce;    /* 25% of standard full color */
 

--- a/app/css/_ui-elements.scss
+++ b/app/css/_ui-elements.scss
@@ -129,7 +129,7 @@ ot-related-targets-vis, ot-related-diseases-vis {
      * Spinners
      */
 
-    .page-progress-spinner{
+    .page-progress-spinner, .block-progress-spinner {
         width:100%;
         height: 100%;
         text-align:center;
@@ -150,6 +150,18 @@ ot-related-targets-vis, ot-related-diseases-vis {
         fill: $secondary-color;
     }
 
+    .block-progress-spinner {
+        padding-top: 0px;
+        
+        ot-progress-spinner {
+            position: absolute;
+            top: 50%;
+
+            svg {
+                margin-top: -50%;
+            }
+        }
+    }
 
 
     /*

--- a/app/css/_ui-elements.scss
+++ b/app/css/_ui-elements.scss
@@ -570,11 +570,13 @@ ot-related-targets-vis, ot-related-diseases-vis {
     }
 
     .epmc_citation_title{
-        font-size: 1.23em;
+        font-size: 16px;
     }
 
     .epmc_citation_subdata {
         padding-left:0px;
+        padding-bottom: 5px;
+        font-size: 12px;
 
         a {
             color:$clr-text;
@@ -586,7 +588,7 @@ ot-related-targets-vis, ot-related-diseases-vis {
     }
 
     .epmc_citation_authors, .epmc_citation_journal, .epmc_citation_source{
-        font-size: 13px;
+        font-size: 12px;
     }
 
     .epmc_citation_authors{

--- a/app/css/_viz-treemap.scss
+++ b/app/css/_viz-treemap.scss
@@ -127,34 +127,57 @@
 .entities{
 	line-height:1.5em
 }
+
 [data-entity="TARGET&DISEASE"],[data-entity=DISEASE],[data-entity=DRUG],[data-entity=GENE]{
 	padding:.15em;margin:0 .25em;line-height:1;display:inline-block;border-radius:.25em;border:1px solid
 }
+
 [data-entity="TARGET&DISEASE"]:after,[data-entity=DISEASE]:after,[data-entity=DRUG]:after,[data-entity=GENE]:after{
 	box-sizing:border-box;font-size:.6em;line-height:1;padding:.25em;border-radius:.25em;text-transform:uppercase;display:inline-block;vertical-align:middle;margin:0 0 .1rem .5rem
 }
+
 [data-entity][data-entity=DRUG]{
-	background:rgba(224,0,132,.2);border-color:#e00084
+	// background:rgba(224,0,132,.2);
+	// border-color:#e00084
+	background: $clr-error-bg;
+	border-color: darken($clr-error-bg, 10%);
 }
 [data-entity][data-entity=DRUG]:after{
-	background:#e00084
+	// background:#e00084
+	background: $clr-error-bg;
 }
+
 [data-entity][data-entity=DISEASE]{
-	background:rgba(67,198,252,.2);border-color:#43c6fc
+	// background:rgba(67,198,252,.2);
+	// border-color:#43c6fc
+	background: $clr-warning-bg;
+	border-color: darken($clr-warning-bg, 10%);
 }
 [data-entity][data-entity=DISEASE]:after{
-	background:#43c6fc
+	// background:#43c6fc
+	background: $clr-warning-bg;
 }
+
 [data-entity][data-entity="TARGET&DISEASE"]{
-	background:rgba(105,145,243,.2);border-color:#6991f3;border:1px dashed
+	// background:rgba(105,145,243,.2);
+	// border-color:#6991f3;
+	// border:1px dashed;
+	background: lighten( $clr-success-bg, 3%);	// for "target&disease" we want a slightly lighter bg
+	border-color: darken( $clr-success-bg , 10%);
 }
 [data-entity][data-entity="TARGET&DISEASE"]:after{
-	background:#6991f3
+	// background:#6991f3
+	background: $clr-success-bg;
 }
+
 /*!*   display: inline; *!*/
 [data-entity][data-entity=GENE]{
-	background:rgba(87,227,81,.2);border-color:#57e351
+	// background:rgba(87,227,81,.2);
+	// border-color:#57e351
+	background: $clr-info-bg;
+	border-color: darken($clr-info-bg, 10%);
 }
 [data-entity][data-entity=GENE]:after{
-	background:#57e351
+	// background:#57e351
+	background: $clr-info-bg;
 }

--- a/app/css/_viz-treemap.scss
+++ b/app/css/_viz-treemap.scss
@@ -86,3 +86,75 @@
     margin-bottom: 8px;
     display: inline-block;
 }
+
+// marked abstract styling (highlights)
+.paper-show-more-or-less{
+	color:#2e9dfd;font-size:.8em;cursor:pointer
+}
+.paper-show-more-or-less.inactive{
+	color:inherit;cursor:text
+}
+.paper-pmid{
+	font-size:.8em;color:#777;margin-bottom:1em
+}
+.paper-authors{
+	margin-top:.5em
+}
+.paper-journal{
+	font-size:.8em;margin-top:.2em;margin-bottom:.2em
+}
+.paper-journal .paper-year{
+	font-weight:700;margin-left:5px;margin-right:5px
+}
+.similar-paper{
+	margin-bottom:10px
+}
+.similar-paper .similar-paper-title{
+	color:#2e9dfd;cursor:pointer
+}
+.paper-abstract-short{
+	position:relative
+}
+.paper-abstract-short:before{
+	position:absolute;bottom:0;height:100%;width:100%;content:"";background:linear-gradient(0deg,#fff 10%,hsla(0,0%,100%,0) 90%);pointer-events:none
+}
+.subsection{
+	margin-top:20px;font-size:.8em;color:#333
+}
+.subsection>.subsection-title{
+	font-size:1em;margin-bottom:10px
+}
+.entities{
+	line-height:1.5em
+}
+[data-entity="TARGET&DISEASE"],[data-entity=DISEASE],[data-entity=DRUG],[data-entity=GENE]{
+	padding:.15em;margin:0 .25em;line-height:1;display:inline-block;border-radius:.25em;border:1px solid
+}
+[data-entity="TARGET&DISEASE"]:after,[data-entity=DISEASE]:after,[data-entity=DRUG]:after,[data-entity=GENE]:after{
+	box-sizing:border-box;font-size:.6em;line-height:1;padding:.25em;border-radius:.25em;text-transform:uppercase;display:inline-block;vertical-align:middle;margin:0 0 .1rem .5rem
+}
+[data-entity][data-entity=DRUG]{
+	background:rgba(224,0,132,.2);border-color:#e00084
+}
+[data-entity][data-entity=DRUG]:after{
+	background:#e00084
+}
+[data-entity][data-entity=DISEASE]{
+	background:rgba(67,198,252,.2);border-color:#43c6fc
+}
+[data-entity][data-entity=DISEASE]:after{
+	background:#43c6fc
+}
+[data-entity][data-entity="TARGET&DISEASE"]{
+	background:rgba(105,145,243,.2);border-color:#6991f3;border:1px dashed
+}
+[data-entity][data-entity="TARGET&DISEASE"]:after{
+	background:#6991f3
+}
+/*!*   display: inline; *!*/
+[data-entity][data-entity=GENE]{
+	background:rgba(87,227,81,.2);border-color:#57e351
+}
+[data-entity][data-entity=GENE]:after{
+	background:#57e351
+}

--- a/app/plugins/bibliography-chips/bibliography-target-chips-directive.js
+++ b/app/plugins/bibliography-chips/bibliography-target-chips-directive.js
@@ -16,7 +16,8 @@ angular.module('otPlugins')
                 target: '=',
                 disease: '=',
                 ext: '=?',
-                label: '='
+                label: '=',
+                q: '=?'
             },
             link: function (scope, elem, attrs) {
                 //
@@ -99,13 +100,34 @@ angular.module('otPlugins')
                     }
                 });
 
+                scope.$watch('q', function (nv, ov) {
+                    if (ov === undefined && nv !== undefined) {
+                        resetSelected();
+                    }
+                });
+
                 function resetSelected () {
                     // selected = selected || [scope.target.approved_symbol]; //.toLowerCase()];
+
                     selected.length = 0;
-                    selected.push({
-                        key: scope.target ? scope.target.id : scope.disease.efo,
-                        label: scope.target ? scope.target.approved_symbol : scope.disease.label
-                    });
+                    var o = {
+                        key: scope.q,
+                        label: scope.q
+                    };
+
+                    if (scope.target) {
+                        o.key = scope.target.id;
+                        o.label = scope.target.approved_symbol;
+                    } else if (scope.disease) {
+                        o.key = scope.disease.efo;
+                        o.label = scope.disease.label;
+                    }
+
+                    selected.push(o);
+                    // selected.push({
+                    //     key: (scope.target ? scope.target.id : scope.disease.efo || scope.q),
+                    //     label: (scope.target ? scope.target.approved_symbol : scope.disease.label) || q
+                    // });
                 }
 
 

--- a/app/plugins/bibliography-chips/bibliography-target-chips.html
+++ b/app/plugins/bibliography-chips/bibliography-target-chips.html
@@ -19,24 +19,85 @@
         <div ng-repeat="page in hits">
 
             <div ng-repeat="hit in page.hits" style="margin-bottom:40px;" class="epmc_citation_container">
-                <!-- <h5 style="margin-bottom:5px"><a ng-href="https://europepmc.org/abstract/med/{{hit._source.id}}">{{hit._source.title}}</a></h5> -->
+                
+                <!-- paper title -->
                 <div class="epmc_citation_title">
                     <a ng-href="https://europepmc.org/abstract/med/{{hit._source.pub_id}}">{{hit._source.title}}</a>
                 </div>
+
+                <!-- paper data -->
                 <div class="epmc_citation_subdata">
-                    <div class="epmc_citation_authors">
-                        <!-- <span ng-repeat="auth in hit._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.full_name}}"&page=1'>{{auth.short_name}}</a><span ng-if="!$last">, </span></span> -->
-
+                    
+                    <!-- authors -->
+                    <div>
                         <span ng-repeat="auth in hit._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1'>{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
-
-                    <!-- </div>
-
-                    <div class="epmc_citation_journal"> -->
-                        <div><span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22">{{hit._source.journal.title}}</a> </span><span ng-show="hit._source.pub_date"> {{hit._source.pub_date | limitTo : 4}}</span><span ng-show="hit._source.journal_reference.volume"> {{hit._source.journal_reference.volume}}</span><span ng-show=
-                        "hit._source.journal_reference.issue">({{hit._source.journal_reference.issue}})</span><span ng-show="hit._source.journal_reference.pgn">:{{hit._source.journal_reference.pgn}}</span></div>
                     </div>
-                    <p ot-more-less-text data="hit._source.abstract" limit=600></p>
+
+                    <!-- journal, year, reference -->
+                    <div>
+                        <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22">{{hit._source.journal.title}}</a></span>
+                        <span ng-show="hit._source.pub_date"><strong>{{hit._source.pub_date | limitTo : 4}}</strong></span>
+                        <span ng-show="hit._source.journal_reference.volume"> {{hit._source.journal_reference.volume}}</span><span ng-show="hit._source.journal_reference.issue">({{hit._source.journal_reference.issue}})</span><span ng-show="hit._source.journal_reference.pgn">:{{hit._source.journal_reference.pgn}}</span>
+                    </div>
+                </div>   
+
+                <div>
+                    <!-- Pills with more details -->
+                    <p>
+                        <!-- show abstract -->
+                        <span ng-show="hit._source.abstract" class="btn btn-default btn-xs">
+                            <span ng-show="!showabstract" ng-click="showabstract=!showabstract; getAbstract(hit._source)">Show abstract</span>
+                            <span ng-show="showabstract" ng-click="showabstract=!showabstract;">Hide abstract</span>
+                        </span>
+                        <span class="small" ng-show="!hit._source.abstract">No abstract available</span>
+                        
+                        <!-- show similar -->
+                        <span class="btn btn-default btn-xs">
+                            <span ng-show="!showsimilar" ng-click="showsimilar=!showsimilar; getSimilar(hit._source)">Show similar</span>
+                            <span ng-show="showsimilar" ng-click="showsimilar=!showsimilar;">Hide similar</span>
+                        </span>
+                    </p>
+                    
+                    <!-- marked abstract -->
+                    <div ng-show="showabstract && hit._source.marked.abstract">
+                        <h5>Abstract</h5>
+                        <div class="small" ng-bind-html="hit._source.marked.abstract"></div>
+                        <p>
+                            <span :id="abstractDomId" class="abstract"></span>
+                            <span data-entity="GENE">Gene</span>
+                            <span data-entity="DISEASE">Disease</span>
+                            <span data-entity="DRUG">Drug</span>
+                            <span data-entity="TARGET&DISEASE">Target and disease</span>
+                        </p>
+                    </div>
+
+                    <!-- similar papers -->
+                    <div ng-show="showsimilar">
+                        <h5>Similar articles</h5>
+                        <div ng-repeat="article in hit._source.similar.hits" class="small">
+                            <div>
+                                <a ng-href="https://europepmc.org/abstract/med/{{article._source.pub_id}}">{{article._source.title}}</a>
+                            </div>
+                            
+                            <div class="epmc_citation_subdata">
+                                    
+                                <!-- authors -->
+                                <div>
+                                    <span ng-repeat="auth in article._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1'>{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
+                                </div>
+            
+                                <!-- journal, year, reference -->
+                                <div>
+                                    <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22">{{article._source.journal.title}}</a></span>
+                                    <span ng-show="article._source.pub_date"><strong>{{article._source.pub_date | limitTo : 4}}</strong></span>
+                                    <span ng-show="article._source.journal_reference.volume"> {{article._source.journal_reference.volume}}</span><span ng-show="article._source.journal_reference.issue">({{article._source.journal_reference.issue}})</span><span ng-show="article._source.journal_reference.pgn">:{{article._source.journal_reference.pgn}}</span>
+                                </div>
+                            </div> 
+                        </div>
+                    </div>
+
                 </div>
+                
             </div>
 
         </div>

--- a/app/plugins/bibliography-chips/bibliography-target-chips.html
+++ b/app/plugins/bibliography-chips/bibliography-target-chips.html
@@ -1,23 +1,31 @@
 <div style="position:relative; min-height:200px">
     
-    <ot-page-progress-spinner isloading="isloading"></ot-page-progress-spinner>
+    <ot-page-progress-spinner isloading="isloading_hits"></ot-page-progress-spinner>
 
-    <div>
-        <!-- <span class="tm-chip btn btn-default disabled">{{selected[0]}}</span> -->
-        <span title="{{sel.key}}" ng-repeat="sel in selected" class="tm-chip btn btn-default" ng-click="onback($index)" ng-if="!$first">{{sel.label || sel.key}} <span class="fa fa-lg fa-times-circle"></span></span>
-        <span title="{{chip.key}}" ng-repeat="chip in chips" class="tm-chip btn btn-primary" ng-click="onclick(chip)">{{chip.label || chip.key}}</span>
+    <!-- chips -->
+    <!-- <ot-progress-spinner ng-show="isloading_aggs && !isloading_hits"></ot-progress-spinner> -->
+    <div style="position:relative">
+        <ot-block-progress-spinner isloading="isloading_aggs && !isloading_hits"></ot-block-progress-spinner>
+        <div ng-show="(chips && chips.length>0) || selected.length>1">
+            <div>
+                <span title="{{sel.key}}" ng-repeat="sel in selected" class="tm-chip btn btn-default" ng-click="onback($index)" ng-if="!$first">{{sel.label || sel.key}} <span class="fa fa-lg fa-times-circle"></span></span>
+                <span title="{{chip.key}}" ng-repeat="chip in chips" class="tm-chip btn btn-primary" ng-click="onclick(chip)">{{chip.label || chip.key}}</span>
+            </div>
+
+            <div style="max-width: 200px; margin-bottom: 20px;">
+                <select class="form-control" ng-model="selectedagg" ng-options="value.id as value.label for value in aggtype"></select>
+            </div>
+        </div>
     </div>
 
-    <div style="max-width: 200px; margin-bottom: 20px;">
-        <select class="form-control" ng-model="selectedagg" ng-options="value.id as value.label for value in aggtype"></select>
-    </div>
-
+    <!-- papers -->
     <div>
         <p ng-show="noftotal && hits[0].total">Showing {{noftotal}} of {{hits[0].total}} results</p>
 
         <!-- container for "pages" -->
         <div ng-repeat="page in hits">
 
+            <!-- paper -->
             <div ng-repeat="hit in page.hits" style="margin-bottom:40px;" class="epmc_citation_container">
                 
                 <!-- paper title -->
@@ -59,6 +67,7 @@
                     </p>
                     
                     <!-- marked abstract -->
+                    <ot-progress-spinner ng-show="showabstract && !hit._source.marked.abstract"></ot-progress-spinner>
                     <div ng-show="showabstract && hit._source.marked.abstract">
                         <h5>Abstract</h5>
                         <div class="small" ng-bind-html="hit._source.marked.abstract"></div>
@@ -72,7 +81,8 @@
                     </div>
 
                     <!-- similar papers -->
-                    <div ng-show="showsimilar">
+                    <ot-progress-spinner ng-show="showsimilar && !hit._source.similar.hits"></ot-progress-spinner>
+                    <div ng-show="showsimilar && hit._source.similar.hits">
                         <h5>Similar articles</h5>
                         <div ng-repeat="article in hit._source.similar.hits" class="small">
                             <div>

--- a/app/plugins/bibliography-chips/bibliography-target-chips.html
+++ b/app/plugins/bibliography-chips/bibliography-target-chips.html
@@ -3,7 +3,6 @@
     <ot-page-progress-spinner isloading="isloading_hits"></ot-page-progress-spinner>
 
     <!-- chips -->
-    <!-- <ot-progress-spinner ng-show="isloading_aggs && !isloading_hits"></ot-progress-spinner> -->
     <div style="position:relative">
         <ot-block-progress-spinner isloading="isloading_aggs && !isloading_hits"></ot-block-progress-spinner>
         <div ng-show="(chips && chips.length>0) || selected.length>1">
@@ -30,7 +29,7 @@
                 
                 <!-- paper title -->
                 <div class="epmc_citation_title">
-                    <a ng-href="https://europepmc.org/abstract/med/{{hit._source.pub_id}}">{{hit._source.title}}</a>
+                    <a ng-href="https://europepmc.org/abstract/med/{{hit._source.pub_id}}" target="_blank">{{hit._source.title}}</a>
                 </div>
 
                 <!-- paper data -->
@@ -38,12 +37,12 @@
                     
                     <!-- authors -->
                     <div>
-                        <span ng-repeat="auth in hit._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1'>{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
+                        <span ng-repeat="auth in hit._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1' target="_blank">{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
                     </div>
 
                     <!-- journal, year, reference -->
                     <div>
-                        <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22">{{hit._source.journal.title}}</a></span>
+                        <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22" target="_blank">{{hit._source.journal.title}}</a></span>
                         <span ng-show="hit._source.pub_date"><strong>{{hit._source.pub_date | limitTo : 4}}</strong></span>
                         <span ng-show="hit._source.journal_reference.volume"> {{hit._source.journal_reference.volume}}</span><span ng-show="hit._source.journal_reference.issue">({{hit._source.journal_reference.issue}})</span><span ng-show="hit._source.journal_reference.pgn">:{{hit._source.journal_reference.pgn}}</span>
                     </div>
@@ -66,43 +65,45 @@
                         </span>
                     </p>
                     
-                    <!-- marked abstract -->
-                    <ot-progress-spinner ng-show="showabstract && !hit._source.marked.abstract"></ot-progress-spinner>
-                    <div ng-show="showabstract && hit._source.marked.abstract">
-                        <h5>Abstract</h5>
-                        <div class="small" ng-bind-html="hit._source.marked.abstract"></div>
-                        <p>
-                            <span :id="abstractDomId" class="abstract"></span>
-                            <span data-entity="GENE">Gene</span>
-                            <span data-entity="DISEASE">Disease</span>
-                            <span data-entity="DRUG">Drug</span>
-                            <span data-entity="TARGET&DISEASE">Target and disease</span>
-                        </p>
-                    </div>
+                    <div style="padding-left: 10px">
+                        <!-- marked abstract -->
+                        <ot-progress-spinner ng-show="showabstract && !hit._source.marked.abstract"></ot-progress-spinner>
+                        <div ng-show="showabstract && hit._source.marked.abstract">
+                            <h5>Abstract</h5>
+                            <div class="small" ng-bind-html="hit._source.marked.abstract"></div>
+                            <p>
+                                <span :id="abstractDomId" class="abstract"></span>
+                                <span data-entity="GENE">Gene</span>
+                                <span data-entity="DISEASE">Disease</span>
+                                <span data-entity="DRUG">Drug</span>
+                                <span data-entity="TARGET&DISEASE">Target and disease</span>
+                            </p>
+                        </div>
 
-                    <!-- similar papers -->
-                    <ot-progress-spinner ng-show="showsimilar && !hit._source.similar.hits"></ot-progress-spinner>
-                    <div ng-show="showsimilar && hit._source.similar.hits">
-                        <h5>Similar articles</h5>
-                        <div ng-repeat="article in hit._source.similar.hits" class="small">
-                            <div>
-                                <a ng-href="https://europepmc.org/abstract/med/{{article._source.pub_id}}">{{article._source.title}}</a>
+                        <!-- similar papers -->
+                        <ot-progress-spinner ng-show="showsimilar && !hit._source.similar.hits"></ot-progress-spinner>
+                        <div ng-show="showsimilar && hit._source.similar.hits">
+                            <h5>Similar articles</h5>
+                            <div ng-repeat="article in hit._source.similar.hits" class="small">
+                                <div>
+                                    <a ng-href="https://europepmc.org/abstract/med/{{article._source.pub_id}}" target="_blank">{{article._source.title}}</a>
+                                </div>
+                                
+                                <div class="epmc_citation_subdata">
+                                        
+                                    <!-- authors -->
+                                    <div>
+                                        <span ng-repeat="auth in article._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1' target="_blank">{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
+                                    </div>
+                
+                                    <!-- journal, year, reference -->
+                                    <div>
+                                        <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22" target="_blank">{{article._source.journal.title}}</a></span>
+                                        <span ng-show="article._source.pub_date"><strong>{{article._source.pub_date | limitTo : 4}}</strong></span>
+                                        <span ng-show="article._source.journal_reference.volume"> {{article._source.journal_reference.volume}}</span><span ng-show="article._source.journal_reference.issue">({{article._source.journal_reference.issue}})</span><span ng-show="article._source.journal_reference.pgn">:{{article._source.journal_reference.pgn}}</span>
+                                    </div>
+                                </div> 
                             </div>
-                            
-                            <div class="epmc_citation_subdata">
-                                    
-                                <!-- authors -->
-                                <div>
-                                    <span ng-repeat="auth in article._source.authors"><a ng-href='https://europepmc.org/search?query=AUTH:"{{auth.ForeName+" "+auth.LastName}}"&page=1'>{{auth.ForeName+" "+auth.LastName}}</a><span ng-if="!$last">, </span></span>
-                                </div>
-            
-                                <!-- journal, year, reference -->
-                                <div>
-                                    <span><a ng-href="https://europepmc.org/search?query=JOURNAL:%22{{hit._source.journal.title}}%22">{{article._source.journal.title}}</a></span>
-                                    <span ng-show="article._source.pub_date"><strong>{{article._source.pub_date | limitTo : 4}}</strong></span>
-                                    <span ng-show="article._source.journal_reference.volume"> {{article._source.journal_reference.volume}}</span><span ng-show="article._source.journal_reference.issue">({{article._source.journal_reference.issue}})</span><span ng-show="article._source.journal_reference.pgn">:{{article._source.journal_reference.pgn}}</span>
-                                </div>
-                            </div> 
                         </div>
                     </div>
 

--- a/app/src/components/drug-summary/drug-summary.html
+++ b/app/src/components/drug-summary/drug-summary.html
@@ -3,6 +3,7 @@
 </div>
 
 <div ng-show="displayName">
+
     <h2>
         Summary page for drug {{displayName}}
     </h2>
@@ -11,6 +12,7 @@
         <img class="drug-img" ng-if="mol_type=='Antibody'" width="200" height="200" src="/imgs/ab.png">
         <img class="drug-img" ng-if="mol_type!='Antibody'" width="200" height="200" src="" id="drugDiagramContainer">
     </div>
+
     <div class="section">
         <h3 class="summary-section-header">General properties</h3>
         <div class="drug-property" style="min-height:200px">
@@ -24,6 +26,7 @@
                 <li style="margin-top:8px;"><b>Molecular formula</b>: {{formula}}</li>
             </ul>
         </div>
+
         <h3 class="summary-section-header">Mechanisms of action</h3>
         <span ot-progress-spinner size="24" ng-show="mechanisms.length==0"></span>
         <table ng-show="mechanisms" class="table ot-evidence-table">
@@ -59,23 +62,26 @@
         <span ng-repeat="disease in diseases">
         <span style="padding-right:8px;margin-top:5px;"><a href=/disease/{{disease.id}}><span class="ot-pill-list disease-list">{{disease.label}}</span>
         </a></span>
-    </span>
+        </span>
     </div>
-<div class="section">
-    <h3 class="summary-section-header">Adverse events</h3>
-    <p class=ot-section-intro>Below is shown the top 20 adverse effects for this drug. An adverse event can be an undesirable experience associated with the use of the drug, including serious drug side effects, product use errors, product quality problems, and therapeutic failures. The source of this data is <a target=_blank href="https://open.fda.gov/drug/event/">OpenFDA</a></p>
 
-    <ul>
-        <li ng-repeat="effect in effects"><span ng-if="!effect.id">{{effect.term}}</span></span><span ng-if="effect.id"><a href="/disease/{{effect.id}}">{{effect.term}}</a></span> ({{effect.count}} reports)</li>
-    </ul>
-    <ot-drug-adverse-events-directive drug="displayName"></ot-drug-adverse-events-directive>
-</div>
+    <div class="section">
+        <h3 class="summary-section-header">Adverse events</h3>
+        <p class=ot-section-intro>Below is shown the top 20 adverse effects for this drug. An adverse event can be an undesirable experience associated with the use of the drug, including serious drug side effects, product use errors, product quality problems, and therapeutic failures. The source of this data is <a target=_blank href="https://open.fda.gov/drug/event/">OpenFDA</a></p>
 
-<div class="section">
-    <h3 class="summary-section-header">External links</h3>
-    <ul>
-        <li>
-            <a target=_blank href="https://www.ebi.ac.uk/chembl/compound/inspect/{{drug}}">Chembl information page for {{drug}}</a>
-        </li>
-    </ul>
+        <ul>
+            <li ng-repeat="effect in effects"><span ng-if="!effect.id">{{effect.term}}</span><span ng-if="effect.id"><a href="/disease/{{effect.id}}">{{effect.term}}</a></span> ({{effect.count}} reports)</li>
+        </ul>
+        <ot-drug-adverse-events-directive drug="displayName"></ot-drug-adverse-events-directive>
+    </div>
+    
+    <div class="section">
+        <h3 class="summary-section-header">External links</h3>
+        <ul>
+            <li>
+                <a target=_blank href="https://www.ebi.ac.uk/chembl/compound/inspect/{{drug}}">Chembl information page for {{drug}}</a>
+            </li>
+        </ul>
+    </div>
+
 </div>

--- a/app/src/components/drug-summary/drug-summary.html
+++ b/app/src/components/drug-summary/drug-summary.html
@@ -75,6 +75,12 @@
         <ot-drug-adverse-events-directive drug="displayName"></ot-drug-adverse-events-directive>
     </div>
     
+    <div class="section" >
+        <h3 class="summary-section-header">Bibliography</h3>
+        <!-- pass the drug display name as generic query term -->
+        <ot-bibliography-target-chips q="displayName"></ot-bibliography-target-chips>
+    </div>
+
     <div class="section">
         <h3 class="summary-section-header">External links</h3>
         <ul>

--- a/app/src/components/spinners/block-progress-spinner-directive.js
+++ b/app/src/components/spinners/block-progress-spinner-directive.js
@@ -1,0 +1,21 @@
+angular.module('otDirectives')
+    /*
+    * This creates a light-box style div with a spinner.
+    * Options:
+    * isloading: variable to use for hiding/showing
+    * size: the size (diameter), in pixels. Defaults to 50. Optional.
+    * stroke: the thickness of the line, in pixels. Defaults to 3. Optional.
+    */
+    .directive('otBlockProgressSpinner', [function () {
+        'use strict';
+
+        return {
+            restrict: 'AE',
+            template: '<div class="block-progress-spinner" ng-show="isloading"><ot-progress-spinner size="{{size || 50}}" stroke="{{stroke || 3}}" class="text-lowlight"></ot-progress-spinner></div>',
+            scope: {
+                size: '@?',
+                stroke: '@?',
+                isloading: '='
+            }
+        };
+    }]);

--- a/app/src/services/utils-service.js
+++ b/app/src/services/utils-service.js
@@ -2,7 +2,7 @@ angular.module('otServices')
 /**
  * Some utility services.
  */
-    .factory('otUtils', ['$window', '$rootScope', 'otConsts', '$sce', function ($window, $rootScope, otConsts, $sce) {
+    .factory('otUtils', ['$window', '$rootScope', 'otConsts', function ($window, $rootScope, otConsts) {
         'use strict';
 
         var otUtilsService = {};


### PR DESCRIPTION
Current version features abstract highlights and runs on drugs summary page.
If abstract is slow to load, we might need to add a spinner.
On drugs summary page we pass a generic query object "q" with the fixed search term (in this case the drug name)