### PR TITLE
Testing updated scripts for travis and netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 [build]
   base    = "/"
   publish = "app/"
-  command = "yarn run setup"
+  command = "yarn run setup && yarn run build-all"
 
 # Read https://www.netlify.com/docs/continuous-deployment/#deploy-contexts
 # to understand how context below works.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "xml": "^1.0.1"
   },
   "scripts": {
-    "setup": "./node_modules/.bin/jspm install && ./node_modules/.bin/gulp build-all",
+    "setup": "./node_modules/.bin/jspm install",
     "build-all": "./node_modules/.bin/gulp build-all",
     "server": "./node_modules/.bin/gulp webserver",
     "full-install": "yarn install && yarn run setup && yarn run build-all",


### PR DESCRIPTION
This is to avoid calling `gulp build-all` twice in travis, which @mkarmona wants to avoid.
The `build` settings in `netlify.toml` appears to be global, so we might want to change these slightly - @peatroot can we review next week with your suggestions about specific scripts...