### PR TITLE
Update handling of GO enrichment on batch search

### DIFF
--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -1,5 +1,5 @@
 angular.module('otDirectives')
-    .directive('multipleTargetsGoSummary', ['$log', '$http', 'otUtils', function ($log, $http, otUtils) {
+    .directive('multipleTargetsGoSummary', ['$http', 'otUtils', function ($http, otUtils) {
         var goCategoryMap = {
             BP: 'Biological Process',
             CC: 'Cellular component',
@@ -44,7 +44,7 @@ angular.module('otDirectives')
             //     }
             // }
             // return tableData;
-            return data
+            return data.result
                 .filter(function (d) { return d.source.substring(0, 3) === 'GO:'; })
                 .map(function (d) {
                     return [
@@ -97,8 +97,7 @@ angular.module('otDirectives')
                     $http.post('https://biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
                         .then(function (resp) {
                             scope.showSpinner = false;
-                            $log.log(resp);
-                            var data = resp.result;
+                            var data = resp.data;
                             $('#target-list-go2-terms').DataTable(otUtils.setTableToolsParams({
                                 'data': parseGOdata(data),
                                 'ordering': true,

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -44,12 +44,16 @@ angular.module('otDirectives')
             //     }
             // }
             // return tableData;
-            return data.filter(d => d.source.substring(0, 3) === 'GO:').map(d => [
-                d.native, // GO term id
-                d.description, // GO term description
-                goCategoryMap[d.source.substring(3, 5)], // GO term category
-                d.p_value // GO term pvalue
-            ]);
+            return data
+                .filter(function (d) { return d.source.substring(0, 3) === 'GO:'; })
+                .map(function (d) {
+                    return [
+                        d.native, // GO term id
+                        d.description, // GO term description
+                        goCategoryMap[d.source.substring(3, 5)], // GO term category
+                        d.p_value // GO term pvalue
+                    ];
+                });
         }
 
         return {

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -79,6 +79,7 @@ angular.module('otDirectives')
                     var opts = {
                         organism: 'hsapiens',
                         user_threshold: 1,
+                        sources: ['GO:MF', 'GO:CC', 'GO:BP'],
                         query: scope.target.map(function (d) { return d.approved_symbol; })
                     };
                     const config = {

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -1,44 +1,55 @@
 angular.module('otDirectives')
     .directive('multipleTargetsGoSummary', ['$http', 'otUtils', 'otConsts', function ($http, otUtils, otConsts) {
+        var goCategoryMap = {
+            BP: 'Biological Process',
+            CC: 'Cellular component',
+            MF: 'Molecular Function'
+        };
         function parseGOdata (data) {
-            var tableData = [];
-            for (var i = 0; i < data.length; i++) {
-                var dataRow = data[i];
-                var dataFields = dataRow.split('\t');
-                if (dataFields[8] && (dataFields[8].substring(0, 3) === 'GO:')) {
-                    var tableRow = [];
-                    // GO term id
-                    tableRow.push(dataFields[8]);
+            // var tableData = [];
+            // for (var i = 0; i < data.length; i++) {
+            //     var dataRow = data[i];
+            //     var dataFields = dataRow.split('\t');
+            //     if (dataFields[8] && (dataFields[8].substring(0, 3) === 'GO:')) {
+            //         var tableRow = [];
+            //         // GO term id
+            //         tableRow.push(dataFields[8]);
 
-                    // GO term description
-                    tableRow.push(dataFields[11]);
+            //         // GO term description
+            //         tableRow.push(dataFields[11]);
 
-                    // GO category
-                    var category;
-                    var symbol = dataFields[9];
-                    if (symbol === 'BP') {
-                        category = 'Biological Process';
-                    } else if (symbol === 'CC') {
-                        category = 'Cellular component';
-                    } else if (symbol === 'MF') {
-                        category = 'Molecular Function';
-                    }
-                    tableRow.push(category);
+            //         // GO category
+            //         var category;
+            //         var symbol = dataFields[9];
+            //         if (symbol === 'BP') {
+            //             category = 'Biological Process';
+            //         } else if (symbol === 'CC') {
+            //             category = 'Cellular component';
+            //         } else if (symbol === 'MF') {
+            //             category = 'Molecular Function';
+            //         }
+            //         tableRow.push(category);
 
-                    // GO term pvalue
-                    tableRow.push(dataFields[2]);
+            //         // GO term pvalue
+            //         tableRow.push(dataFields[2]);
 
-                    var targetsInTerm = dataFields[13].split(',');
-                    // GO term number of targets
-                    tableRow.push(targetsInTerm.length);
+            //         var targetsInTerm = dataFields[13].split(',');
+            //         // GO term number of targets
+            //         tableRow.push(targetsInTerm.length);
 
-                    // GO targets
-                    tableRow.push(targetsInTerm.join(', '));
+            //         // GO targets
+            //         tableRow.push(targetsInTerm.join(', '));
 
-                    tableData.push(tableRow);
-                }
-            }
-            return tableData;
+            //         tableData.push(tableRow);
+            //     }
+            // }
+            // return tableData;
+            return data.filter(d => d.source.substring(0, 3) === 'GO:').map(d => [
+                d.native, // GO term id
+                d.description, // GO term description
+                goCategoryMap[d.source.substring(3, 5)], // GO term category
+                d.p_value // GO term pvalue
+            ]);
         }
 
         return {
@@ -55,13 +66,20 @@ angular.module('otDirectives')
                     }
                     scope.showSpinner = true;
 
-                    // var targetIds = scope.target.map(function (t) {
-                    //     return t.ensembl_gene_id;
-                    // });
+
+                    // (previously, gProfiler had an unusual POST format)  
+                    // curl -X POST -d 'output=mini&organism=hsapiens&significant=1&sort_by_structure=1&ordered_query=0&as_ranges=0&no_iea=0&underrep=0&hierfiltering=none&user_thr=1&min_set_size=0&max_set_size=0&threshold_algo=analytical&domain_size_type=annotated&query=braf+pten+brca1+brca2' http://biit.cs.ut.ee/gprofiler/
+                    // var opts = 'output=mini&organism=hsapiens&significant=1&sort_by_structure=1&ordered_query=0&as_ranges=0&no_iea=0&underrep=0&hierfiltering=none&user_thr=1&min_set_size=0&max_set_size=0&threshold_algo=analytical&domain_size_type=annotated&query=' + (scope.target.map(function (d) { return d.approved_symbol; }).join('+'));
 
                     // Call gProfiler to get enriched GO terms
-                    // curl -X POST -d 'output=mini&organism=hsapiens&significant=1&sort_by_structure=1&ordered_query=0&as_ranges=0&no_iea=0&underrep=0&hierfiltering=none&user_thr=1&min_set_size=0&max_set_size=0&threshold_algo=analytical&domain_size_type=annotated&query=braf+pten+brca1+brca2' http://biit.cs.ut.ee/gprofiler/
-                    var opts = 'output=mini&organism=hsapiens&significant=1&sort_by_structure=1&ordered_query=0&as_ranges=0&no_iea=0&underrep=0&hierfiltering=none&user_thr=1&min_set_size=0&max_set_size=0&threshold_algo=analytical&domain_size_type=annotated&query=' + (scope.target.map(function (d) { return d.approved_symbol; }).join('+'));
+                    var opts = {
+                        organism: 'hsapiens',
+                        user_threshold: 1,
+                        query: scope.target.map(function (d) { return d.approved_symbol; })
+                    };
+                    const config = {
+                        headers: {'Content-Type': 'application/json'}
+                    };
 
                     // The proxy is setting this header now
                     // var httpConfig = {
@@ -70,12 +88,12 @@ angular.module('otDirectives')
                     //     }
                     // };
                     // $http.post('https://biit.cs.ut.ee/gprofiler/', opts, httpConfig)
-                    $http.post(otConsts.PROXY + 'biit.cs.ut.ee/gprofiler/', opts)
+                    $http.post(otConsts.PROXY + 'biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
                         .then(function (resp) {
                             scope.showSpinner = false;
-                            var data = resp.data;
+                            var data = resp.result;
                             $('#target-list-go2-terms').DataTable(otUtils.setTableToolsParams({
-                                'data': parseGOdata(data.split('\n')),
+                                'data': parseGOdata(data),
                                 'ordering': true,
                                 'order': [[3, 'asc']],
                                 'autoWidth': false,

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -1,5 +1,5 @@
 angular.module('otDirectives')
-    .directive('multipleTargetsGoSummary', ['$http', 'otUtils', function ($http, otUtils) {
+    .directive('multipleTargetsGoSummary', ['$log', '$http', 'otUtils', function ($log, $http, otUtils) {
         var goCategoryMap = {
             BP: 'Biological Process',
             CC: 'Cellular component',
@@ -97,6 +97,7 @@ angular.module('otDirectives')
                     $http.post('https://biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
                         .then(function (resp) {
                             scope.showSpinner = false;
+                            $log.log(resp);
                             var data = resp.result;
                             $('#target-list-go2-terms').DataTable(otUtils.setTableToolsParams({
                                 'data': parseGOdata(data),

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -1,5 +1,5 @@
 angular.module('otDirectives')
-    .directive('multipleTargetsGoSummary', ['$http', 'otUtils', 'otConsts', function ($http, otUtils, otConsts) {
+    .directive('multipleTargetsGoSummary', ['$http', 'otUtils', function ($http, otUtils) {
         var goCategoryMap = {
             BP: 'Biological Process',
             CC: 'Cellular component',
@@ -92,7 +92,8 @@ angular.module('otDirectives')
                     //     }
                     // };
                     // $http.post('https://biit.cs.ut.ee/gprofiler/', opts, httpConfig)
-                    $http.post(otConsts.PROXY + 'biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
+                    // $http.post(otConsts.PROXY + 'biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
+                    $http.post('https://biit.cs.ut.ee/gprofiler/api/gost/profile/', opts, config)
                         .then(function (resp) {
                             scope.showSpinner = false;
                             var data = resp.result;

--- a/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary-directive.js
@@ -49,7 +49,7 @@ angular.module('otDirectives')
                 .map(function (d) {
                     return [
                         d.native, // GO term id
-                        d.description, // GO term description
+                        d.name, // GO term description
                         goCategoryMap[d.source.substring(3, 5)], // GO term category
                         d.p_value // GO term pvalue
                     ];

--- a/app/src/components/multiple-targets/multiple-targets-go-summary.html
+++ b/app/src/components/multiple-targets/multiple-targets-go-summary.html
@@ -24,8 +24,8 @@
                 <th>GO term description</th>
                 <th>Category</th>
                 <th>Relevance (p-value)<ot-popover key="ENRICHMENT.GO"></ot-popover></th>
-                <th>Number of targets</th>
-                <th>Targets</th>
+                <!-- <th>Number of targets</th>
+                <th>Targets</th> -->
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
GO enrichment on the batch search is achieved by making a POST request to [GProfiler](http://biit.cs.ut.ee/gprofiler/). See https://github.com/opentargets/platform/issues/430.

Previously, the url used was `otConsts.PROXY + https://biit.cs.ut.ee/gprofiler/`, with a header of `Content-Type: application/x-www-form-urlencoded; charset=UTF-8`. The free-text body passed was as below.
```
var body = 'output=mini&organism=hsapiens&significant=1&sort_by_structure=1&ordered_query=0&as_ranges=0&no_iea=0&underrep=0&hierfiltering=none&user_thr=1&min_set_size=0&max_set_size=0&threshold_algo=analytical&domain_size_type=annotated&query=' + (scope.target.map(function (d) { return d.approved_symbol; }).join('+'));
```

Unfortunately, this is no longer supported it seems, hence the breaking of this section of the batch search page. GProfiler does still offer an API, which is more RESTful, but it is not quite the same. The new url is `https://biit.cs.ut.ee/gprofiler/api/gost/profile/`, with a header of `Content-Type: application/json` and body as below.
```
var body = {
    organism: 'hsapiens',
    user_threshold: 1,
    sources: ['GO:MF', 'GO:CC', 'GO:BP'],
    query: scope.target.map(function (d) { return d.approved_symbol; })
};
```

The main differences are:
* No use of proxy. Having run this by @mkarmona, the proxy speeds up user queries by caching, but batch search queries are likely to always be different, so it is probably reasonable to remove in this case.
* Lack of target lists per GO term. Previously, the GO enrichment table listed which targets were enriched for a given GO term (row). This is no longer possible, since the new response does not contain this information.