### PR TITLE
Adding build steps to Dockerfile; adding option to add custom .css styling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
-app/config/custom.json
 .vscode
 **/*~
+Dockerfile
 node_modules
+app/build
 jspm_packages
 .sass-cache
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,38 @@
+# Multi-stage dockerfile where the 1st stage builds the app on a specific version of node,
+# and the 2nd stage sets up the latest nginx:alpine.
+
+# ============================== node/build section =====================================================
+FROM node:8.15-alpine as build_section
+
+# build dependencies:
+RUN apk update
+RUN apk add --update make
+RUN apk add --update g++
+RUN apk add --update python2
+RUN apk add --update git
+
+# copy build config:
+COPY ./*.* /var/www/
+COPY ./LICENSE /var/www/
+WORKDIR /var/www
+# install project dependencies via yarn:
+RUN yarn install
+# copy rest of code (we do this only here to avoid "install dependencies" step above each time *only* the code changes):
+COPY . /var/www/
+# build code:
+RUN yarn run full-install
+
+# ============================== nginx section =====================================================
 FROM nginx:alpine
 
 # use jq to update custom.json at runtime
 RUN apk update && apk add jq
 
-# copy built app - npm install && npm run setup need to have happened
-COPY ./app /var/www/app/
+# copy build result from 1st stage
+COPY --from=build_section /var/www/app/ /var/www/app/
+
+# append custom CSS to the end of main .css file:
+RUN ( ls /var/www/app/config/custom_style.css && cat /var/www/app/config/custom_style.css >> /var/www/app/build/OpenTargetsWebapp.min.css) || echo 'No custom .css'
 
 #move self-signed certificates in the right place
 COPY ./nginx_conf/server.crt /usr/share/nginx/

--- a/README.md
+++ b/README.md
@@ -68,12 +68,16 @@ docker run -d -p 8443:443 -p 8080:80 \
  quay.io/opentargets/webapp
 ```
 
-It is also possible to specify a separate server for all /proxy calls (calls to external services and data resources used in some
+By default, the webapp /proxy should redirect to the proxy that is built into the rest api container.
+But it is also possible to specify a separate server for all /proxy calls (calls to external services and data resources used in some
 pages). These are the variables:
 - `PROXY_SCHEME` (`http` or `https` are valid options, `$REST_API_SCHEME` is the default)
 - `PROXY_SERVER` (if not set, `$REST_API_SERVER` is the default)
 - `PROXY_PORT` (if not set, `$REST_API_PORT` is the default)
 - `PROXY_PATH` (if not set, `proxy` is the default)
+
+:information_source: When using the rest api built-in proxy, additional domains can be included by adding them to the appropriate nginx
+configuration file. See https://github.com/opentargets/rest_api/ documentation for more details.
 
 Any other modifications, including changing the `custom.json` for the container,
 cannot be made at runtime. You'd have to create your own fork/modifications.

--- a/app/config/readme.md
+++ b/app/config/readme.md
@@ -5,4 +5,7 @@ Directory structure:
  - default.json
  - custom.json (optional, overrides values in default.json)
 
- At build time, the files in all directories are crunched into one file config.json which is loaded when bootstrapping the app.
+At build time, the files in all directories are crunched into one file config.json which is loaded when bootstrapping the app.
+
+Custom styling can be added to the file `custom_style.css` to override some of the runtime styling.
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,9 +4,9 @@
 export REST_API_SCHEME=${REST_API_SCHEME:=https}
 export REST_API_SERVER=${REST_API_SERVER:=platform-api.opentargets.io}
 export REST_API_PORT=${REST_API_PORT:=443}
-export PROXY_SCHEME=${PROXY_SCHEME:=https}
-export PROXY_SERVER=${PROXY_SERVER:=platform-api.opentargets.io}
-export PROXY_PORT=${PROXY_PORT:=443}
+export PROXY_SCHEME=${PROXY_SCHEME:=$REST_API_SCHEME}
+export PROXY_SERVER=${PROXY_SERVER:=$REST_API_SERVER}
+export PROXY_PORT=${PROXY_PORT:=$REST_API_PORT}
 export PROXY_PATH=${PROXY_PATH:=proxy}
 
 


### PR DESCRIPTION
This PR changes the Dockerfile into a multi-stage dockerfile to be able to build using specific node version, before adding the build result to the /var/www folder used by nginx.

Contents:
- added build steps to Dockerfile
- included an option to overwrite some runtime .css styling, where a custom .css file is taken and appended to the full .css produced by the build step file
- updated documentation (mainly parts regarding docker options)