### PR TITLE
Solution to allow configuring a custom icon to appear on a section panel

### DIFF
--- a/app/css/_page.scss
+++ b/app/css/_page.scss
@@ -64,6 +64,12 @@ body{
     @include border-radius( 1.5em );
 }
 
+.ot-section-icon {
+    position:absolute;
+    right: 0px;
+    width: 45px;
+}
+
 .ot-main-container {
     width:100%;
     background: $primary-background-color;

--- a/app/src/pages/disease-profile/disease.html
+++ b/app/src/pages/disease-profile/disease.html
@@ -29,8 +29,11 @@
                 <uib-accordion close-others="false">
                     <div uib-accordion-group ng-repeat="section in sections" is-open="section.defaultVisibility" attr-section-name="{{section.name}}" class="panel-default" id="{{section.config.id}}">
                         <uib-accordion-heading>
-                            <div style="position:relative" ng-show="section.new">
+                            <div style="position:relative" ng-show="!section.icon && section.new" ng-click="section.currentVisibility = !section.currentVisibility">
                                 <div class="ot-section-new"><span>New</span></div>
+                            </div>
+                            <div style="position:relative" ng-show="section.icon" ng-click="section.currentVisibility = !section.currentVisibility">
+                                <div class="ot-section-icon"><img src="{{section.icon}}"style="width: 100%;"></img></div>
                             </div>
                             <span ng-click='section.currentVisibility = !section.currentVisibility'>{{section.heading}}</span>
                         </uib-accordion-heading>

--- a/app/src/pages/evidence/target-disease.html
+++ b/app/src/pages/evidence/target-disease.html
@@ -90,8 +90,11 @@
                     <!-- <div uib-accordion-group ng-repeat="section in sections" is-open="section.defaultVisibility" attr-section-name="{{section.name}}" class="panel-default" ng-if="search.association_score.datatypes[section.config.datatype]>0"></div>     -->
                         <!-- accordion header -->
                         <uib-accordion-heading>
-                            <div style="position:relative" ng-show="section.new">
+                            <div style="position:relative" ng-show="!section.icon && section.new" ng-click="section.currentVisibility = !section.currentVisibility">
                                 <div class="ot-section-new"><span>New</span></div>
+                            </div>
+                            <div style="position:relative" ng-show="section.icon" ng-click="section.currentVisibility = !section.currentVisibility">
+                                <div class="ot-section-icon"><img src="{{section.icon}}"style="width: 100%;"></img></div>
                             </div>
                             <span ng-click='section.currentVisibility = !section.currentVisibility' class="text-nolight" ng-class="{ 'text-disabled': search.fd[section.config.datatype]==0 }">{{section.heading}}</span>
                         </uib-accordion-heading>

--- a/app/src/pages/target-profile/target.html
+++ b/app/src/pages/target-profile/target.html
@@ -92,8 +92,11 @@
                 <uib-accordion close-others="false">
                     <div uib-accordion-group ng-repeat="section in sections" is-open="section.defaultVisibility" attr-section-name="{{section.name}}" class="panel-default" id="{{section.config.id}}">
                         <uib-accordion-heading>
-                            <div style="position:relative" ng-show="section.new">
+                            <div style="position:relative" ng-show="!section.icon && section.new" ng-click="section.currentVisibility = !section.currentVisibility">
                                 <div class="ot-section-new"><span>New</span></div>
+                            </div>
+                            <div style="position:relative" ng-show="section.icon" ng-click="section.currentVisibility = !section.currentVisibility">
+                                <div class="ot-section-icon"><img src="{{section.icon}}"style="width: 100%;"></img></div>
                             </div>
                             <span ng-click='section.currentVisibility = !section.currentVisibility'>{{section.heading}}</span>
                         </uib-accordion-heading>


### PR DESCRIPTION
The configured icon appears on the far right side of the panel and  is useful to help users quickly see
which panels contain custom "in house" data.

This PR also fixes issue https://github.com/opentargets/platform/issues/511