### PR TITLE
Remove EBI analytics config + make it generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ will be publicly available after a few minutes on quay.io
 docker pull quay.io/opentargets/webapp:<yourbranchname>
 ```
 
-### Configuring analytics
+## Configuring analytics
 
 The frontend can publish events to both Matomo (former Piwik) and Google Analytics. To enable this,
 make sure you ovewrite the following files at runtime:

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ will be publicly available after a few minutes on quay.io
 docker pull quay.io/opentargets/webapp:<yourbranchname>
 ```
 
+### Configuring analytics
+
+The frontend can publish events to both Matomo (former Piwik) and Google Analytics. To enable this,
+make sure you ovewrite the following files at runtime:
+
+- Google Analytics: `/var/www/app/ga.js`
+- Matomo: `/var/www/app/piwik.js`
+
+
 ## Further documentation
 
 ### [Plugins](/app/plugins/readme.md)

--- a/app/ga.js
+++ b/app/ga.js
@@ -1,13 +1,1 @@
-(function(i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    i[r] = i[r] || function() {
-        (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date();
-    a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m)
-})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-ga('create', 'UA-101860681-5', 'auto');// add your tracking ID here.
-// ga('send', 'pageview'); // not needed as handler triggered
+/** overwrite this file with your own Google Analytics file */

--- a/app/index-tmpl.html
+++ b/app/index-tmpl.html
@@ -94,6 +94,11 @@
         <!-- Piwik -->
         <script type="text/javascript" src="./piwik.js"></script>
         <!-- End Piwik Code -->
+        
+        <!-- Google Analytics -->
+        <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-101860681-5"></script> -->
+        <script type="text/javascript" src="./ga.js"></script>
+        <!-- End Google Analytics Code -->
     </head>
 
     <body id="ot-page-app">
@@ -346,11 +351,6 @@
             <script src="./vendor/pdfobject.min.js"></script>
 
 
-
-            <!-- Google Analytics -->
-            <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-101860681-5"></script> -->
-            <script type="text/javascript" src="./ga.js"></script>
-            <!-- End Google Analytics Code -->
 
             <!-- Log page app session -->
             <!--<ot-log-session></ot-log-session>-->

--- a/app/index-tmpl.html
+++ b/app/index-tmpl.html
@@ -91,12 +91,12 @@
             /*}*/
         </style>
 
-
+        <!-- Piwik -->
+        <script type="text/javascript" src="./piwik.js"></script>
+        <!-- End Piwik Code -->
     </head>
 
     <body id="ot-page-app">
-        <!-- piwik opt out -->
-        <!-- <iframe frameborder=no width=600px height=200px src=http://demo.piwik.org/index.php?module=CoreAdminHome&action=optOut&language=en></iframe> -->
 
         <div class="ot-page-wrapper" ng-controller="PageController">
 
@@ -346,11 +346,6 @@
             <script src="./vendor/pdfobject.min.js"></script>
 
 
-
-            <!-- Piwik -->
-            <script type="text/javascript" src="./piwik.js"></script>
-            <noscript><p><img src="//opentargets.piwikpro.com/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
-            <!-- End Piwik Code -->
 
             <!-- Google Analytics -->
             <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-101860681-5"></script> -->

--- a/app/piwik.js
+++ b/app/piwik.js
@@ -1,11 +1,1 @@
-var _paq = _paq || [];
-_paq.push(['setDomains', ['*.www.targetvalidation.org']]);
-// _paq.push(['trackPageView']);
-_paq.push(['enableLinkTracking']);
-(function () {
-    var u = '//opentargets.piwikpro.com/';
-    _paq.push(['setTrackerUrl', u + 'piwik.php']);
-    _paq.push(['setSiteId', 1]);
-    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-    g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'piwik.js'; s.parentNode.insertBefore(g, s);
-})();
+/** overwrite this file with your own matomo/piwik .js */

--- a/app/src/services/google-analytics-service.js
+++ b/app/src/services/google-analytics-service.js
@@ -9,13 +9,13 @@ angular.module('otServices')
      */
     .factory('otGoogleAnalytics', ['$location', function ($location) {
         function trackPageView () {
-            if ($location.host() === 'www.targetvalidation.org') {
+            if (typeof ga !== 'undefined') {
                 ga('send', 'pageview', $location.path());
             }
         }
 
         function trackEvent (category, action, label, value) {
-            if ($location.host() === 'www.targetvalidation.org') {
+            if (typeof ga !== 'undefined') {
                 ga('send', 'event', category, action, label, value);
             }
         }


### PR DESCRIPTION
Fix for https://github.com/opentargets/platform/issues/565. This PR:
- removes EBI specific configuration that was referring
to the public portal.
- changes the default behavior to "no analytics" (no piwik,
no google analytics). Makes changes to ensure this
scenario works.
- adds documentation section in README.md to explain
how one can configure the frontend to connect to his
own analytics installation.
- removes the "noscript" type of tracking by piwik