### PR TITLE
Fixes to show "reload page" message when session times out

### DIFF
--- a/app/src/components/plugin-loader/plugin-loader-directive.js
+++ b/app/src/components/plugin-loader/plugin-loader-directive.js
@@ -1,5 +1,5 @@
 angular.module('otPlugins')
-    .directive('otPluginLoader', ['$compile', '$timeout', 'otLazy', '$q', '$analytics', 'otGoogleAnalytics', function ($compile, $timeout, otLazy, $q, $analytics, otGoogleAnalytics) {
+    .directive('otPluginLoader', ['$rootScope', '$compile', '$timeout', 'otLazy', '$q', '$analytics', 'otGoogleAnalytics', function ($rootScope, $compile, $timeout, otLazy, $q, $analytics, otGoogleAnalytics) {
         return {
             restrict: 'E',
             scope: {
@@ -76,6 +76,10 @@ angular.module('otPlugins')
                                     var compiled = $compile(template)(scope);
                                     element.append(compiled);
                                 }, 0);
+                            },
+                            function (reason) {
+                                $rootScope.showApiErrorMsg = true;
+                                window.scrollTo(0, 0);
                             });
                     } else {
                         // while (element[0].firstChild) {

--- a/app/src/js/controllers.js
+++ b/app/src/js/controllers.js
@@ -17,6 +17,12 @@ angular.module('otControllers')
             $.fn.dataTable.ext.search = [];
         });
 
+        // Make sure the showApiErrorMsg flag is set to true when there
+        // is an error when navigating (e.g. caused by a session timeout)
+        $rootScope.$on('$routeChangeError', function () {
+            $rootScope.showApiErrorMsg = true;
+        });
+
         $rootScope.$on('cttvApiError', function (event, data) {
             if (data.status === 403) {
                 $rootScope.showApiErrorMsg = true;

--- a/app/src/services/api-service.js
+++ b/app/src/services/api-service.js
@@ -172,7 +172,7 @@ angular.module('otServices')
         otApiService.defaultErrorHandler = function (error, trackCall) {
             $log.warn('CTTV API ERROR:', error);
             countRequest(trackCall === false ? undefined : false);
-            if (error.status === 403) {
+            if ([0, 403].indexOf(error.status) > -1) {
                 $rootScope.showApiErrorMsg = true;
             }
             if (error.status >= 500) {


### PR DESCRIPTION
This PR ensures the "session expired / reload page" message appears when a session is expired. See screenshot below.

![image](https://user-images.githubusercontent.com/2900303/60270183-21e8f900-98f0-11e9-85d7-337df8a956ca.png)


It currently works for the following scenarios:
1. session is expired and user starts typing in the search box
2. session is expired and user navigates to another page (e.g. from homepage to associations page)
3. session is expired and user expands a panel in the profile page (only works for panels that have a dependency)

There is one scenario which is _not_ solved yet:
4. session is expired and user expands a panel in the profile page which has _no_ dependencies...

...and this is because we are not able to find an easy way to handle errors resulting from `$compile()` (or its result function). See here: https://github.com/opentargets/webapp/blob/master/app/src/components/plugin-loader/plugin-loader-directive.js#L76 . Any tips are welcome! 