### PR TITLE
Fix datatype expansion on target association page

### DIFF
--- a/app/src/components/target-associations/target-associations-table-directive.js
+++ b/app/src/components/target-associations/target-associations-table-directive.js
@@ -115,28 +115,17 @@ angular.module('otDirectives')
                 ],
                 'processing': false,
                 'serverSide': true,
-                // 'searchDelay': 800,
-                'columns': (function () {
-                    var a = [];
-                    for (var i = 0; i < cols.length; i++) {
-                        a.push({'title': '<div><span title=\'' + cols[i].title + '\'>' + cols[i].title + '</span></div>', name: cols[i].name});
-                    }
-                    return a;
-                })(),
+                'columns': a,
                 'columnDefs': [
                     {
                         'targets': [1, 2],
                         'visible': false
                     },
                     {
-                        'targets': [3, 4, 5, 6, 7, 8, 9],
-                        'asSorting': ['desc', 'asc']
-                    },
-                    {
                         'orderable': false,
-                        'targets': 11
+                        'targets': [a.length - 1]
                     },
-                    {'orderSequence': ['desc', 'asc'], 'targets': [3, 4, 5, 6, 7, 8, 9, 10, 11]},
+                    {'orderSequence': ['desc', 'asc'], 'targets': range(3, a.length - 1)},
                     {'orderSequence': ['asc', 'desc'], 'targets': [0]}
                 ],
                 'ajax': function (data, cbak) {
@@ -272,19 +261,6 @@ angular.module('otDirectives')
                             cbak(o);
                         });
                 },
-                // 'columns': a,
-                // 'columnDefs': [
-                //     {
-                //         'targets': [1, 2],
-                //         'visible': false
-                //     },
-                //     {
-                //         'orderable': false,
-                //         'targets': [a.length - 1]
-                //     },
-                //     {'orderSequence': ['desc', 'asc'], 'targets': range(3, a.length - 1)},
-                //     {'orderSequence': ['asc', 'desc'], 'targets': [0]}
-                // ],
                 'order': [[3, 'desc']],
                 'orderMulti': false,
                 'autoWidth': false,


### PR DESCRIPTION
A cleanup after pull request https://github.com/opentargets/webapp/pull/306
deactivated the active version of a piece of duplicated logic rather than
the dead one, breaking the feature.

This resulted in garbled output when the feature was enabled, as the table was provided with data for more columns of data than it had actual columns; all numbers after the one that was supposed to be expanded were listed under the wrong header, and the last visible column displayed numbers as text on a coloured background instead of disease names.

This patch re-implements commit 6448532716c9836a679d13679f6b0d7d3514cb79
(Remove redundant definitions), to restore the functionality of commit
edd4e8d7c1ba0f798cb20a54306849df25edb666 (adding auto-expansion for
heatmap if datatype is configured to expand).