### PR TITLE
Add Ensembl view

### DIFF
--- a/app/config/general/default.json
+++ b/app/config/general/default.json
@@ -366,6 +366,15 @@
             "config": {
                 "id": "biomarkers"
             }
+         },
+         {
+            "name": "ensemble",
+            "element": "ot-ensemble",
+            "heading": "Ensemble",
+            "track": true,
+            "config": {
+                "id": "ensemble"
+            }
          }
     ],
 
@@ -603,7 +612,7 @@
             {"label":"IL2RA", "id":"ENSG00000134460"},
             {"label":"ACHE", "id":"ENSG00000087085"},
             {"label":"SNCA", "id":"ENSG00000145335"},
-            
+
             {"label":"BRAF", "id":"ENSG00000157764"},
             {"label":"BRCA2", "id":"ENSG00000139618"},
             {"label":"KRAS", "id":"ENSG00000133703"},

--- a/app/plugins/ensemble/ensembel-directive.js
+++ b/app/plugins/ensemble/ensembel-directive.js
@@ -1,0 +1,22 @@
+/**
+ * Text mining plugin
+ */
+angular.module('otPlugins')
+    .directive('otEnsemble', ['otConfig', 'otUtils', '$sce', function (otConfig, otUtils, $sce) {
+        'use strict';
+        return {
+            restrict: 'E',
+            templateUrl: 'plugins/ensemble/ensemble.html',
+            scope: {
+                target: '=',
+                disease: '=',
+                ext: '=?'       // optional external object for communication
+            },
+            link: function (scope) {
+                scope.ext = scope.ext || {};
+                scope.ext.ensemble_url = $sce.trustAsResourceUrl(
+                    'https://uswest.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=' + scope.target.ensembl_gene_id
+                )
+            }
+        };
+    }]);

--- a/app/plugins/ensemble/ensemble.html
+++ b/app/plugins/ensemble/ensemble.html
@@ -1,0 +1,4 @@
+<!-- plugin template -->
+<div class="ot-ensemble">
+    <iframe ng-src='{{ ext.ensemble_url }}' frameborder="none" style="width: 100%; height: 500px"></iframe>
+</div>


### PR DESCRIPTION
Adds an additional plugin to embed an iframe pointing to a Gene's Ensembl page:

![image](https://user-images.githubusercontent.com/700444/68903019-acd75e00-06ee-11ea-8ae7-95f95e0c810b.png)
