### PR TITLE
Only apply ExpressionAtlas specific filtering to expression atlas data.

### DIFF
--- a/app/src/components/rna-expression-table/rna-expression-table-directive.js
+++ b/app/src/components/rna-expression-table/rna-expression-table-directive.js
@@ -88,7 +88,7 @@ angular.module('otDirectives')
                         var row = [];
 
                         try {
-                            var isExpressionAtlas = (otConsts.datasources.EXPRESSION_ATLAS.id === evidence.provenance_type.database.id.toLowerCase());
+                            var isExpressionAtlas = (otConsts.datasources.EXPRESSION_ATLAS.id === item.evidence.provenance_type.database.id.toLowerCase());
 
                             // col 0: data origin: public / private
                             row.push((item.access_level === otConsts.ACCESS_LEVEL_PUBLIC) ? otConsts.ACCESS_LEVEL_PUBLIC_DIR : otConsts.ACCESS_LEVEL_PRIVATE_DIR);

--- a/app/src/components/rna-expression-table/rna-expression-table-directive.js
+++ b/app/src/components/rna-expression-table/rna-expression-table-directive.js
@@ -88,6 +88,8 @@ angular.module('otDirectives')
                         var row = [];
 
                         try {
+                            var isExpressionAtlas = (otConsts.datasources.EXPRESSION_ATLAS.id === evidence.provenance_type.database.id.toLowerCase());
+
                             // col 0: data origin: public / private
                             row.push((item.access_level === otConsts.ACCESS_LEVEL_PUBLIC) ? otConsts.ACCESS_LEVEL_PUBLIC_DIR : otConsts.ACCESS_LEVEL_PRIVATE_DIR);
 
@@ -97,8 +99,11 @@ angular.module('otDirectives')
                             // comparison
                             row.push(item.evidence.comparison_name);
 
-                            // activity
-                            var activityUrl = item.evidence.urls.filter(function (i) { return i.nice_name === 'Gene expression in Expression Atlas'; })[0].url || '';
+                            if (isExpressionAtlas) {
+                                var activityUrl = item.evidence.urls.filter(function (i) { return i.nice_name === 'Gene expression in Expression Atlas'; })[0].url || '';
+                            } else {
+                                var activityUrl = item.evidence.urls[0];
+                            }
                             var activity = item.target.activity.split('_').shift();
                             row.push('<a class=\'ot-external-link\' href=\'' + activityUrl + '\' target=\'_blank\'>' + activity + '</a>');
 
@@ -118,8 +123,12 @@ angular.module('otDirectives')
                             row.push(item.evidence.log2_fold_change.percentile_rank);
 
                             // experiment overview
-                            var expID = (item.evidence.urls.filter(function (i) { return i.nice_name === 'ArrayExpress Experiment overview'; })[0].url || '').split('/').pop();
-                            var expOverview = 'https://www.ebi.ac.uk/gxa/experiments/' + expID + '/Experiment%20Design';
+                            if (isExpressionAtlas) {
+                                var expID = (item.evidence.urls.filter(function (i) { return i.nice_name === 'ArrayExpress Experiment overview'; })[0].url || '').split('/').pop();
+                                var expOverview = 'https://www.ebi.ac.uk/gxa/experiments/' + expID + '/Experiment%20Design';
+                            } else {
+                                var expOverview = (item.evidence.urls[2] || item.evidence.urls[0]).url || otDictionary.NA; 
+                            }
                             row.push('<a class=\'ot-external-link\' href=\'' + expOverview + '\' target=\'_blank\'>' + (item.evidence.experiment_overview || 'Experiment overview and raw data') + '</a>');
 
 

--- a/app/src/components/rna-expression-table/rna-expression-table-directive.js
+++ b/app/src/components/rna-expression-table/rna-expression-table-directive.js
@@ -102,7 +102,7 @@ angular.module('otDirectives')
                             if (isExpressionAtlas) {
                                 var activityUrl = item.evidence.urls.filter(function (i) { return i.nice_name === 'Gene expression in Expression Atlas'; })[0].url || '';
                             } else {
-                                var activityUrl = item.evidence.urls[0];
+                                var activityUrl = item.evidence.urls[0].url;
                             }
                             var activity = item.target.activity.split('_').shift();
                             row.push('<a class=\'ot-external-link\' href=\'' + activityUrl + '\' target=\'_blank\'>' + activity + '</a>');


### PR DESCRIPTION
When fixing opentargets/platform#812 support for private RNA Expression data (i.e. not Express Atlas) was broken, as Expression Atlas specific filtering as added to the RNA-Expression table on the association evidence page. This adds qualifiers to these statements so that they only apply to Exression Atlas data, and work as they used to for other data types.