### PR TITLE
Update outlinks to beta rewrite

### DIFF
--- a/app/src/components/drug-summary/drug-summary.html
+++ b/app/src/components/drug-summary/drug-summary.html
@@ -12,7 +12,7 @@
             We are currently redesigning and rebuilding the Open Targets Platform with new features.
         </p>
         <p>
-            For a preview of the new Platform interface, please see <b><a href="http://alpha.targetvalidation.org/drug/{{drug}}">the new profile page for {{displayName}}</a></b>
+            For a preview of the new Platform interface, please see <b><a href="http://beta.targetvalidation.org/drug/{{drug}}">the new profile page for {{displayName}}</a></b>
         </p>
     </div>
 

--- a/app/src/pages/disease-associations/disease-associations.html
+++ b/app/src/pages/disease-associations/disease-associations.html
@@ -36,7 +36,7 @@
                 We are currently redesigning and rebuilding the Open Targets Platform with new features and a new approach to scoring.
             </p>
             <p>
-                For a preview of the new Platform interface, please see <b><a href="http://alpha.targetvalidation.org/disease/{{search.query}}/associations">the redesigned association page for {{search.label}}</a></b>
+                For a preview of the new Platform interface, please see <b><a href="http://beta.targetvalidation.org/disease/{{search.query}}/associations">the redesigned association page for {{search.label}}</a></b>
             </p>
         </div>
 

--- a/app/src/pages/disease-profile/disease.html
+++ b/app/src/pages/disease-profile/disease.html
@@ -11,7 +11,7 @@
                     We are currently redesigning and rebuilding the Open Targets Platform with new features.
                 </p>
                 <p>
-                    For a preview of the new Platform interface, please see <b><a href="http://alpha.targetvalidation.org/disease/{{diseaseId}}">the new profile page for {{disease.label}}</a></b>
+                    For a preview of the new Platform interface, please see <b><a href="http://beta.targetvalidation.org/disease/{{diseaseId}}">the new profile page for {{disease.label}}</a></b>
                 </p>
             </div>
 

--- a/app/src/pages/evidence/target-disease.html
+++ b/app/src/pages/evidence/target-disease.html
@@ -10,7 +10,7 @@
         </div>
     </div>
 
-    <!-- <div ng-if="otConfig.showNoticeWithLinkToAlphaRewrite" class="rewrite-alpha-release-notice-container">
+    <div ng-if="otConfig.showNoticeWithLinkToAlphaRewrite" class="rewrite-alpha-release-notice-container">
         <p>
             <b>** Important Notice **</b>
         </p>
@@ -20,12 +20,12 @@
         <p>
             For a preview of the new Platform interface, please see 
             <b>
-                <a href="http://alpha.targetvalidation.org/evidence/{{search.info.gene.ensembl_gene_id}}/{{search.info.efo.efo_code}}">
+                <a href="http://beta.targetvalidation.org/evidence/{{search.info.gene.ensembl_gene_id}}/{{search.info.efo.efo_code}}">
                     the redesigned evidence page for {{(search.info.gene.approved_symbol || search.info.gene.ensembl_external_name)}} in {{search.info.efo.label}}
                 </a>
             </b>
         </p>
-    </div> -->
+    </div>
 
     <!-- page header with flower and overview -->
     <div class="container">

--- a/app/src/pages/target-associations/target-associations.html
+++ b/app/src/pages/target-associations/target-associations.html
@@ -37,7 +37,7 @@
                 We are currently redesigning and rebuilding the Open Targets Platform with new features and a new approach to scoring.
             </p>
             <p>
-                For a preview of the new Platform interface, please see <b><a href="http://alpha.targetvalidation.org/target/{{search.query}}/associations">the updated {{search.label}} association page</a></b>
+                For a preview of the new Platform interface, please see <b><a href="http://beta.targetvalidation.org/target/{{search.query}}/associations">the updated {{search.label}} association page</a></b>
             </p>
         </div>
 

--- a/app/src/pages/target-profile/target.html
+++ b/app/src/pages/target-profile/target.html
@@ -11,7 +11,7 @@
                     We are currently redesigning and rebuilding the Open Targets Platform with new features.
                 </p>
                 <p>
-                    For a preview of the new Platform interface, please see <b><a href="http://alpha.targetvalidation.org/target/{{targetId}}">the new profile page for {{target.symbol}}</a></b>
+                    For a preview of the new Platform interface, please see <b><a href="http://beta.targetvalidation.org/target/{{targetId}}">the new profile page for {{target.symbol}}</a></b>
                 </p>
             </div>
 


### PR DESCRIPTION
Update the links to rewrite to point "beta" instead of "alpha". Also include notice in evidence page.

**NOTE**
Please wait until beta version is ready before merging this PR.