### PR TITLE
Use Netlify _redirects file

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-/*    https://beta.targetvalidation.org/:splat    301!

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+/                   https://beta.targetvalidation.org/
+/target/*           https://beta.targetvalidation.org/target/:splat
+/disease/*          https://beta.targetvalidation.org/disease/:splat

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
-/                   https://beta.targetvalidation.org/
-/target/*           https://beta.targetvalidation.org/target/:splat
-/disease/*          https://beta.targetvalidation.org/disease/:splat
+/                   https://beta.targetvalidation.org/                301!
+/target/*           https://beta.targetvalidation.org/target/:splat   301!
+/disease/*          https://beta.targetvalidation.org/disease/:splat  301!

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,1 @@
-/                   https://beta.targetvalidation.org/                301!
-/target/*           https://beta.targetvalidation.org/target/:splat   301!
-/disease/*          https://beta.targetvalidation.org/disease/:splat  301!
+/*    https://beta.targetvalidation.org/:splat    301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,7 +1,3 @@
-/proxy/* https://platform-api.opentargets.io/proxy/:splat 200!
-/* /index.html 200
-# Redirect domain aliases to primary domain
-https://platform.opentargets.org/* https://www.targetvalidation.org/:splat 301!
-
-# These extra rules are required because HTTPS is not forced
-http://platform.opentargets.org/* https://www.targetvalidation.org/:splat 301!
+/                   https://beta.targetvalidation.org/
+/target/*           https://beta.targetvalidation.org/target/:splat
+/disease/*          https://beta.targetvalidation.org/disease/:splat

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,3 +1,1 @@
-/                   https://beta.targetvalidation.org/
-/target/*           https://beta.targetvalidation.org/target/:splat
-/disease/*          https://beta.targetvalidation.org/disease/:splat
+/*    https://beta.targetvalidation.org/:splat    301!


### PR DESCRIPTION
This PR is an initial attempt to address https://github.com/opentargets/platform/issues/1482 by using an [`_redirects` file](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) in Netlify to redirect users from `targetvalidation.org` to `platform.opentargets.org`