### PR TITLE
Decommission Angular webapp 

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -1,4 +1,2 @@
-/target/*           https://beta.targetvalidation.org/target/:splat   301!
-/summary  drug=:id  https://beta.targetvalidation.org/drug/:id/       301!
-/disease/*          https://beta.targetvalidation.org/disease/:splat  301!
-/index.html         https://beta.targetvalidation.org/                301!
+/summary  drug=:id  https://platform.opentargets.org/drug/:id/     301!
+/*                  https://platform.opentargets.org/:splat        301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,5 +1,4 @@
 /target/*           https://beta.targetvalidation.org/target/:splat   301!
-/summary drug=:id   https://beta.targetvalidation.org/drug/:id        301!
+/summary  drug=:id  https://beta.targetvalidation.org/drug/:id        301!
 /disease/*          https://beta.targetvalidation.org/disease/:splat  301!
 /index.html         https://beta.targetvalidation.org/                301!
-/*                  https://beta.targetvalidation.org/:splat          301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,4 +1,4 @@
 /target/*           https://beta.targetvalidation.org/target/:splat   301!
-/summary  drug=:id  https://beta.targetvalidation.org/drug/:id        301!
+/summary  drug=:id  https://beta.targetvalidation.org/drug/:id/       301!
 /disease/*          https://beta.targetvalidation.org/disease/:splat  301!
 /index.html         https://beta.targetvalidation.org/                301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,5 +1,5 @@
-/target/*         https://beta.targetvalidation.org/target/:splat   301!
-/summary?drug=*   https://beta.targetvalidation.org/drug/:splat     301!
-/disease/*        https://beta.targetvalidation.org/disease/:splat  301!
-/index.html       https://beta.targetvalidation.org/                301!
-/*                https://beta.targetvalidation.org/:splat          301!
+/target/*           https://beta.targetvalidation.org/target/:splat   301!
+/summary drug=:id   https://beta.targetvalidation.org/drug/:id        301!
+/disease/*          https://beta.targetvalidation.org/disease/:splat  301!
+/index.html         https://beta.targetvalidation.org/                301!
+/*                  https://beta.targetvalidation.org/:splat          301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,2 +1,5 @@
-/summary?drug=*   https://beta.targetvalidation.org/drug/:splat    301!
-/*                https://beta.targetvalidation.org/:splat         301!
+/target/*         https://beta.targetvalidation.org/target/:splat   301!
+/summary?drug=*   https://beta.targetvalidation.org/drug/:splat     301!
+/disease/*        https://beta.targetvalidation.org/disease/:splat  301!
+/index.html       https://beta.targetvalidation.org/                301!
+/*                https://beta.targetvalidation.org/:splat          301!

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,7 +1,2 @@
-/proxy/* https://platform-api.opentargets.io/proxy/:splat 200!
-/* /index.html 200
-# Redirect domain aliases to primary domain
-https://platform.opentargets.org/* https://www.targetvalidation.org/:splat 301!
-
-# These extra rules are required because HTTPS is not forced
-http://platform.opentargets.org/* https://www.targetvalidation.org/:splat 301!
+/summary?drug=*   https://beta.targetvalidation.org/drug/:splat    301!
+/*                https://beta.targetvalidation.org/:splat         301!

--- a/app/index-tmpl.html
+++ b/app/index-tmpl.html
@@ -102,125 +102,8 @@
             <!-- main page content -->
             <div class="ot-main-container">
 
-                <!-- Masthead and navigation -->
-                <!-- HP only has notifications -->
-                <!-- other pages have full masthead -->
-                <div ng-controller="MastheadController">
-                <div class="masthead ng-cloak" ng-class="location.path()!=='/' ? 'masthead-border' : ''">
-                    <div ng-show="opts.showResponsiveSearch" class="masthead-dimmer"></div>
-
-                    <div class="container">
-
-                        <div class="row" >
-
-                            <!-- single col contains everything and content is floated -->
-                            <div class="col-xs-12">
-
-                                <!-- OT Platform logo -->
-                                <div class="ot_logo pull-left" ng-if="location.path()!=='/'" ng-class="{'invisible':opts.showResponsiveSearch}">
-                                    <a href="/">
-                                        <img src="imgs/logo/otp-logo-w-b.svg" class="intro-logo-tvp" width="195px" alt="Open Targets logo"/>
-                                    </a>
-                                </div>
-
-
-                                <!-- 1: search (on other pages only) -->
-                                <div ng-if="location.path()!=='/'" class="masthead-search-container pull-right" ng-class="{'invisible':opts.showResponsiveSearch}">
-                                    <!-- full search box: hide on small screens -->
-                                    <div ot-search-box class="hidden-xs hidden-sm masthead-search-menu"></div>
-
-                                    <!-- responsive search box-->
-                                    <div class="masthead-responsive-search hidden-md hidden-lg">
-                                        <span ng-click="opts.showResponsiveSearch=!opts.showResponsiveSearch" class="fa fa-lg masthead-responsive-search-icon fa-search"></span>
-                                    </div>
-                                </div>
-
-                                <div ng-show="opts.showResponsiveSearch" class="masthead-responsive-search-panel">
-                                    <div ng-click="opts.showResponsiveSearch=!opts.showResponsiveSearch" class="masthead-responsive-search pull-right">
-                                        <span class="fa fa-lg fa-times masthead-responsive-search-icon"></span>
-                                    </div>
-                                    <div ot-search-box></div>
-                                </div>
-
-                                <!-- 2: notifications (as required) -->
-                                <div masthead-notifications-menu class="masthead-notifications-menu pull-right" ng-class="{'invisible':opts.showResponsiveSearch}"></div>
-
-
-                                <!-- 3: menu (on other pages only) -->
-                                <div class="pull-right" ng-class="{'invisible':opts.showResponsiveSearch}">
-                                    <!-- navigation menu : hide on small screen-->
-                                    <ot-masthead-navigation-menu class="hidden-xs hidden-sm"></ot-masthead-navigation-menu>
-
-                                    <!-- here should have hamburger -->
-                                    <ot-masthead-navigation-menu is-hamburger="true" class="hidden-md hidden-lg"></ot-masthead-navigation-menu>
-                                </div>
-
-                                <!-- 4: Batch search icon (on other pages only) -->
-                                <div ng-if="location.path()!=='/'" class="pull-right hidden-xs hidden-sm masthead-batch-search-icon" ng-class="{'invisible':opts.showResponsiveSearch}">
-                                    <span uib-popover="Search for several targets" popover-animation="true" popover-class="batch-search-popover" popover-trigger="'mouseenter'" popover-placement="bottom-right" >
-                                        <a href="/batch-search">
-                                            <i class="fa fa-file-text-o fa-lg"></i>
-                                        </a>
-                                    </span>
-                                </div>
-
-                            </div>
-
-                        </div>
-                    </div>
-                </div><!-- end masthead -->
-                </div>
-
-
-                <!-- ERRORS -->
-                <div class="container main-alert-container">
-                    <div class="row">
-                        <div class="col-sm-12">
-                            <div> </div>
-                            <!-- Authentication error -->
-                            <div uib-alert class="alert-danger" ng-show="showApiErrorMsg" ng-cloak close="showApiErrorMsg=false">
-                                 Your session has expired, reload the page to authenticate again <button class="btn btn-default btn-sm" ng-click="reloadPage()">Reload</button>
-                            </div>
-
-                            <!-- API ERROR 500 -->
-                            <div uib-alert class="alert-danger" ng-show="showApiError500" close="showApiError500=false" ng-cloak>A problem retrieving data has occurred. Please try to reload the page. If the problem persists please contact our <a target="_blank" href="mailto:support@targetvalidation.org?Subject=Open Targets Platform - help request">support team</a>
-                                <button class="btn btn-default btn-sm" ng-click="reloadPage()">Reload</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-
-                <!-- FEEDBACK BUTTON -->
-                <!-- <div ng-cloak class="ot-feedback-button hidden-xs" ng-controller="FeedbackController" ng-click="openFeedbackForm()" ng-show="location.path()=='/'"> -->
-                <div class="ot-feedback-button hidden-xs ng-scope" ng-controller="FeedbackController" ng-class="{'ot-feedback-button-round': location.path()!='/' }">
-                    <a target="_blank" href="mailto:support@targetvalidation.org?Subject=Open Targets Platform - feedback&amp;body=Page URL: https://www.targetvalidation.org/">
-                        <div>Feedback</div>
-                    </a>
-                </div>
-
-
-
-                <!-- Social media button -->
-                <div ng-cloak class="ot-social-panel hidden-xs" ng-controller="FeedbackController" ng-show="location.path()=='/'" ng-click="showSocialMedia=!showSocialMedia">
-                    <div ng-show="showSocialMedia">
-                        <a target="_blank" href="https://www.linkedin.com/company/centre-for-therapeutic-target-validation"><div class="ot-social-panel-item ot-social-panel-linkedin"></div></a>
-                        <a target="_blank" href="http://twitter.com/targetvalidate"><div class="ot-social-panel-item ot-social-panel-twitter"></div></a>
-                        <a target="_blank" href="https://www.facebook.com/OpenTargets/"><div class="ot-social-panel-item ot-social-panel-facebook"></div></a>
-
-                        <a target="_blank" href="https://github.com/opentargets"><div class="ot-social-panel-item ot-social-panel-github"></div></a>
-                        <a target="_blank" href="https://medium.com/opentargets"><div class="ot-social-panel-item ot-social-panel-medium"></div></a>
-                        <a target="_blank" href="https://www.youtube.com/channel/UCLMrondxbT0DIGx5nGOSYOQ"><div class="ot-social-panel-item ot-social-panel-youtube"></div></a>
-                    </div>
-                    <div class="ot-social-panel-follow" ng-show="!showSocialMedia">Follow us</div>
-                </div>
-
-
-                <!--<div class="container">-->
                 <div>
-                    <!-- beta ribbon if not in www -->
-                    <ot-beta-ribbon></ot-beta-ribbon>
-
+                    
                     <!-- ie < 9? -->
                     <!--[if lt IE 9]>
                     <div class="alert alert-danger">
@@ -237,7 +120,29 @@
 
                     <!-- Content -->
 
-                    <div ng-view autoscroll="true"></div>
+                    <div class="container">
+                        <div class="row" style="text-align:center;font-size: 16px;margin-top:30px">
+                            <a href="https://platform.opentargets.org/">
+                                <img class="img" src="imgs/logo/ot_logo_webheader_280x104.png" />
+                            </a>
+                            <h2>
+                                Hello!
+                            </h2>
+                            <p>
+                                Thank you for visiting the Open Targets Platform.
+                            </p>
+                            <p>
+                                To coincide with the <a href="https://blog.opentargets.org/2021/04/29/next-gen-platform-released">launch of the next-generation Platform in April 2021</a>, 
+                                <br/>we have updated the URL for the Platform to <a href="https://platform.opentargets.org">https://platform.opentargets.org</a>. 
+                            </p>
+                            <p>
+                                Please update your bookmarks and click the button below to be redirected.
+                            </p>
+                            <p>
+                                <a href="https://platform.opentargets.org/" class="btn btn-primary">Visit the new Platform</a>
+                            </p>
+                        </div>
+                    </div>
 
                     <!-- End Content -->
 
@@ -246,34 +151,9 @@
             </div>
             <!-- end main page content -->
 
-            <!-- new footer form - test -->
-            <div ng-if="location.path()!=='/' && otConfig.enableFooterSignupForm" style="width:100%; background:#2f2d36">
-                <div class="container">
-                    <div class="row" style="border-bottom: 1px solid #403f48;">
-                        <div class="col-sm-9 col-md-6" >
-                            <h4 class="footer-section-header">Sign up to our newsletter</h4>
-                            <div id="mc_embed_signup" style="margin-bottom: 15px">
-
-                                <form action="https://opentargets.us17.list-manage.com/subscribe/post?u=d11d0467053c1d4b918eb8738&amp;id=4e0ec8b344" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-                                <!-- <form action="https://opentargets.us17.list-manage.com/subscribe/post?u=d11d0467053c1d4b918eb8738&amp;id=aa83c5e27a" method="post" id="mc-embedded-subscribe-form-hs" name="mc-embedded-subscribe-form-hs" target="_blank" novalidate> -->
-                                    <div id="mc_embed_signup_scroll" class="input-group">
-                                    <input type="email" value="" name="EMAIL" class="form-control" id="mce-EMAIL" placeholder="email address" required>
-                                    <div class="input-group-btn"><button type="submit" class="btn btn-success">Sign up</button></div>
-                                    </div>
-                                    <!-- <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d11d0467053c1d4b918eb8738_aa83c5e27a" tabindex="-1" value=""></div> -->
-                                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d11d0467053c1d4b918eb8738_4e0ec8b344" tabindex="-1" value=""></div>
-                                </form>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- end footer form test -->
-
             <!-- Footer -->
             <div ot-footer></div>
             <!-- End Footer-->
-
 
             <!-- require.js -->
             <script src="jspm_packages/system.js"></script>
@@ -285,110 +165,7 @@
             <!-- Components -->
             <script type="text/javascript" src="build/components-OpenTargetsWebapp.min.js?v=%VER%"></script>
 
-            <!-- Blob.js (needed by FileSaver) -->
-            <script type="text/javascript" language="javascript" src="vendor/Blob.js"></script>
-
-            <!-- Pathway viewer -->
-            
-            <script type="text/javascript" language="javascript" src="https://reactome.org/DiagramJs/diagram/diagram.nocache.js?v=%VER%" async></script>
-            
-            <!-- <script>
-                // test alternative approach for reactome script
-
-                // var script = document.createElement("script");
-                // script.type = "text/javascript";
-                // script.src = 'https://reactome.org/DiagramJs/diagram/diagram.nocache.js?v=%VER%';
-                // script.onload = function (e) {
-                //     console.log('onload: ', e);
-                // }
-                // script.onerror = function (e) {
-                //     console.log('onerror: ', e);
-                // }
-                // document.body.appendChild(script);
-            </script> -->
-
-
-            <!-- Protein viewer -->
-            <!--<script type="text/javascript" language="javascript" src="vendor/bio-pv.min.js"></script>-->
-
-            <!-- PDB viewers -->
-            <!-- <link rel="stylesheet" href="https://wwwdev.ebi.ac.uk/pdbe/widgets/pdb-component-library/css/pdb.component.library.beta-1.0.0.min.css" /> -->
-            <!-- <script src="//wwwdev.ebi.ac.uk/pdbe/widgets/pdb-component-library/libs/Three.js"></script>
-            <script src="//wwwdev.ebi.ac.uk/pdbe/widgets/pdb-component-library/js/pdb.component.library.min.2.0.js"></script> -->
-            <!-- <script src="/vendor/pdbWidgets/Three.js"></script>
-            <script src="/vendor/pdbWidgets/pdb.component.library.complete.js"></script> -->
-
-            <!-- ie9 cors support -->
-            <!--[if lte IE 9]>
-            <script language="JavaScript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js"></script>
-            <![endif]-->
-
-            <!-- NEW datatable -->
-            <script type="text/javascript" src="https://cdn.datatables.net/s/bs/jq-2.1.4,dt-1.10.10,b-1.1.0,b-flash-1.1.0,b-html5-1.1.0/datatables.min.js"></script>
-                
-            <script type="text/javascript" src="build/bootstrap/dist/js/bootstrap.min.js?v=%VER%"></script>
-            <script type="text/javascript" language="javascript" src="./vendor/bs.js?v=%VER%"></script>
-
-            <!-- Cookie notification-->
-            <script type="text/javascript" id="cookiebanner" src="./vendor/cookiebanner/cookiebanner.min.js"
-                    data-message="<a href='#'></a>This website requires cookies and the limited processing of your personal data in order to function. By using the site you are agreeing to this as outlined in our <a href='https://www.ebi.ac.uk/data-protection/privacy-notice/open-targets' target='_blank'>Privacy Notice</a> and <a href='terms-of-use'>Terms of Use.</a>"
-                    data-linkmsg = ""
-                    data-moreinfo = "#"
-                    data-height="50px"
-                    data-link="#337ab7"
-                    data-fontfamily="inherit"
-                    data-close-text="<span class='btn btn-success btn-xs'><i class='fa fa-check-circle'></i> OK</span>">
-            </script>
-
-
-            <!-- Pdf viewer -->
-            <script src="./vendor/pdfobject.min.js"></script>
-
-
-
-            <!-- Piwik -->
-            <script type="text/javascript" src="./piwik.js"></script>
-            <noscript><p><img src="//opentargets.piwikpro.com/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
-            <!-- End Piwik Code -->
-
-            <!-- Google Analytics -->
-            <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-101860681-5"></script> -->
-            <script type="text/javascript" src="./ga.js"></script>
-            <!-- End Google Analytics Code -->
-
-            <!-- Log page app session -->
-            <!--<ot-log-session></ot-log-session>-->
-
         </div>
-
-
-        <!-- Ghost blog stuff -->
-        <script type="text/javascript" src="https://blog.opentargets.org/public/ghost-sdk.min.js?v=4bb0226015"></script>
-        <script type="text/javascript">
-            ghost.init({
-                clientId: "ghost-frontend",
-                clientSecret: "5fd090001a81"
-            });
-        </script>
-
-
-        <!-- Facebook feeds scripts -->
-        <div id="fb-root"></div>
-        <script>(function(d, s, id) {
-          var js, fjs = d.getElementsByTagName(s)[0];
-          if (d.getElementById(id)) return;
-          js = d.createElement(s); js.id = id;
-          js.src = "https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v2.7";
-          fjs.parentNode.insertBefore(js, fjs);
-        }(document, 'script', 'facebook-jssdk'));</script>
-
-        <!-- Twitter feeds stuff -->
-        <script src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-
-        <!-- Start of HubSpot Embed Code -->
-        <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/4040749.js"></script>
-        <!-- End of HubSpot Embed Code -->
 
     </body>
 


### PR DESCRIPTION
This PR addresses the https://github.com/opentargets/platform/issues/1502:

- Creation of `_redirects` file, redirecting users from targetvalidation.org to platform.opentargets.org
- Update to `index-tmpl.html` file with notice about new Platform URL and button to redirect

Using the deploy preview, I have verified the redirect works for:

- Homepage: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/
- Target profile page: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/target/ENSG00000232810
- Target associations page: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/target/ENSG00000091831/associations
- Disease profile page: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/disease/MONDO_0008903
- Disease associations page: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/disease/Orphanet_648/associations
- Drug profile page*: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/summary?drug=CHEMBL122
- Variants page: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/variants
- Data downloads: https://deploy-preview-324--paratrooper-antelope-70721.netlify.app/downloads/data

*Note: with the drug profile page, Netlify redirect correctly parses for the ChEMBL ID but the redirect URL also includes the `summary?drug=CHEMBLxxx` fragment. I attempted to resolve with different settings in the `_redirects` file but had no luck. However, the extra fragment does not impact the redirect.  